### PR TITLE
docs: rename to MeMesh Plugin, clean up phantom references, add pre-release checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# MeMesh Project Instructions
+# MeMesh Plugin Project Instructions
 
 ## Documentation-Code Synchronization (MANDATORY)
 
@@ -100,7 +100,7 @@ src/
 ### Testing
 
 - Framework: vitest
-- All tests: `npm test` (1971+ tests across 121 files)
+- All tests: `npm test` (2202+ tests across 121+ files)
 - Single-thread mode to prevent worker leaks
 - Tests MUST pass before any commit
 
@@ -115,3 +115,44 @@ src/
 - sqlite-vec: pinned to exact `"0.1.3"` (not semver range)
 - Native dependencies: better-sqlite3, sqlite-vec, onnxruntime-node
 - Cloud-only mode when native deps unavailable
+
+---
+
+## Pre-Release Checklist (MANDATORY before npm publish)
+
+### 1. Version Sync
+- [ ] `package.json` version matches `plugin.json` version
+- [ ] All README files reference correct version
+- [ ] `docs/api/API_REFERENCE.md` header version is correct
+- [ ] `docs/ARCHITECTURE.md` header version is correct
+
+### 2. Tool List Accuracy
+- [ ] `docs/api/API_REFERENCE.md` lists exactly the 8 tools defined in `src/mcp/ToolDefinitions.ts`
+- [ ] `docs/COMMANDS.md` tool list matches ToolDefinitions.ts
+- [ ] No phantom tools documented (tools that don't exist in code)
+- [ ] No undocumented tools (tools in code but not in docs)
+
+### 3. Architecture Doc Accuracy
+- [ ] `docs/ARCHITECTURE.md` module tree matches actual `src/` structure
+- [ ] No references to deleted modules (AutoTagger, SmartMemoryQuery, memesh-sync-remote, etc.)
+- [ ] Hook list matches `hooks/hooks.json`
+- [ ] Plugin config description matches `plugin.json`, `.mcp.json`
+
+### 4. Naming Consistency
+- [ ] Product name is "MeMesh Plugin" (not just "MeMesh") across all READMEs and docs
+- [ ] GitHub About description says "MeMesh Plugin"
+
+### 5. Build & Test
+- [ ] `npm run build` succeeds
+- [ ] `npm test` passes (all tests)
+- [ ] `npm run typecheck` passes
+- [ ] No TODO/FIXME/STUB in src/ files
+
+### 6. Package Contents
+- [ ] `package.json` `files` array includes all necessary files
+- [ ] `npm pack --dry-run` output contains expected files
+- [ ] postinstall script works: `node scripts/postinstall-new.js`
+
+### 7. External Sync
+- [ ] Obsidian `Projects/MeMesh-Plugin/` notes updated to current version
+- [ ] MeMesh KG entities reflect current project status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,11 @@ src/
 │   ├── CheckpointDetector.ts    # Checkpoint detection
 │   └── MCPToolInterface.ts      # Tool interface base
 └── db/
-    └── DatabaseManager.ts        # SQLite connection + migrations
+    ├── ConnectionPool.ts         # SQLite connection pool
+    ├── IDatabaseAdapter.ts       # Database adapter interface
+    ├── QueryCache.ts             # Query result caching
+    └── adapters/
+        └── BetterSqlite3Adapter.ts  # better-sqlite3 implementation
 ```
 
 ### Key Design Decisions
@@ -134,12 +138,12 @@ src/
 
 ### 3. Architecture Doc Accuracy
 - [ ] `docs/ARCHITECTURE.md` module tree matches actual `src/` structure
-- [ ] No references to deleted modules (AutoTagger, SmartMemoryQuery, memesh-sync-remote, etc.)
+- [ ] No references to removed tools (memesh-sync-remote, memesh-cloud-sync, etc.)
 - [ ] Hook list matches `hooks/hooks.json`
 - [ ] Plugin config description matches `plugin.json`, `.mcp.json`
 
 ### 4. Naming Consistency
-- [ ] Product name is "MeMesh Plugin" (not just "MeMesh") across all READMEs and docs
+- [ ] Product name is "MeMesh Plugin" in titles, headers, and first mentions across all READMEs and docs (body text may use "MeMesh" as brand shorthand)
 - [ ] GitHub About description says "MeMesh Plugin"
 
 ### 5. Build & Test

--- a/README.de.md
+++ b/README.de.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Deine KI-Coding-Sitzungen verdienen ein Gedächtnis.
 
-MeMesh gibt Claude Code ein persistentes, durchsuchbares Gedächtnis — damit jede Sitzung auf der vorherigen aufbaut.
+MeMesh Plugin gibt Claude Code ein persistentes, durchsuchbares Gedächtnis — damit jede Sitzung auf der vorherigen aufbaut.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.es.md
+++ b/README.es.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Tus sesiones de programación con IA merecen memoria.
 
-MeMesh le da a Claude Code una memoria persistente y consultable — para que cada sesión se base en la anterior.
+MeMesh Plugin le da a Claude Code una memoria persistente y consultable — para que cada sesión se base en la anterior.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Vos sessions de code avec l'IA méritent une mémoire.
 
-MeMesh offre à Claude Code une mémoire persistante et consultable — chaque session s'appuie sur la précédente.
+MeMesh Plugin offre à Claude Code une mémoire persistante et consultable — chaque session s'appuie sur la précédente.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.id.md
+++ b/README.id.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Sesi coding AI Anda layak memiliki memori.
 
-MeMesh memberikan Claude Code memori yang persisten dan dapat dicari — sehingga setiap sesi melanjutkan dari yang terakhir.
+MeMesh Plugin memberikan Claude Code memori yang persisten dan dapat dicari — sehingga setiap sesi melanjutkan dari yang terakhir.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### あなたの AI コーディングセッションにはメモリが必要です。
 
-MeMesh は Claude Code に永続的で検索可能なメモリを提供し、すべてのセッションが前回の続きから始まります。
+MeMesh Plugin は Claude Code に永続的で検索可能なメモリを提供し、すべてのセッションが前回の続きから始まります。
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### AI 코딩 세션에도 기억이 필요합니다.
 
-MeMesh는 Claude Code에 영구적이고 검색 가능한 메모리를 제공하여, 모든 세션이 이전 세션 위에 쌓이도록 합니다.
+MeMesh Plugin은 Claude Code에 영구적이고 검색 가능한 메모리를 제공하여, 모든 세션이 이전 세션 위에 쌓이도록 합니다.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <img src="docs/images/memesh-logo.svg" alt="MeMesh" width="80" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Your AI coding sessions deserve memory.
 
-MeMesh gives Claude Code persistent, searchable memory — so every session builds on the last.
+MeMesh Plugin gives Claude Code persistent, searchable memory — so every session builds on the last.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)
@@ -32,7 +32,7 @@ npm install -g @pcircle/memesh
 
 You're deep into a project with Claude Code. You made important decisions three sessions ago — which auth library, why you chose that database schema, what patterns to follow. But Claude doesn't remember. You repeat yourself. You lose context. You waste time.
 
-**MeMesh fixes this.** It gives Claude a persistent, searchable memory that grows with your project.
+**MeMesh Plugin fixes this.** It gives Claude a persistent, searchable memory that grows with your project.
 
 ---
 
@@ -140,7 +140,7 @@ All data stays on your machine with automatic 90-day retention.
 
 ## How is this different from CLAUDE.md?
 
-| | CLAUDE.md | MeMesh |
+| | CLAUDE.md | MeMesh Plugin |
 |---|-----------|--------|
 | **Purpose** | Static instructions for Claude | Living memory that grows with your project |
 | **Search** | Manual text search | Semantic search by meaning |
@@ -148,7 +148,7 @@ All data stays on your machine with automatic 90-day retention.
 | **Recall** | Always loaded (can get long) | Surfaces relevant context on demand |
 | **Scope** | General preferences | Project-specific knowledge graph |
 
-**They work together.** CLAUDE.md tells Claude *how* to work. MeMesh remembers *what* you've built.
+**They work together.** CLAUDE.md tells Claude *how* to work. MeMesh Plugin remembers *what* you've built.
 
 ---
 
@@ -166,7 +166,7 @@ All data stays on your machine with automatic 90-day retention.
 
 ## Visual Explorer (Streamlit UI)
 
-MeMesh includes an interactive web UI for exploring your knowledge graph visually.
+MeMesh Plugin includes an interactive web UI for exploring your knowledge graph visually.
 
 **Dashboard** — Overview of your knowledge base with entity statistics, type distribution, tag trends, and growth over time.
 
@@ -228,7 +228,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant U as You (in Claude Code)
-    participant M as MeMesh MCP
+    participant M as MeMesh Plugin
     participant KG as Knowledge Graph
     participant E as Embeddings (ONNX)
 

--- a/README.th.md
+++ b/README.th.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### เซสชันเขียนโค้ดกับ AI ของคุณสมควรมีหน่วยความจำ
 
-MeMesh มอบหน่วยความจำถาวรที่ค้นหาได้ให้ Claude Code — ทำให้ทุกเซสชันต่อยอดจากเซสชันก่อนหน้า
+MeMesh Plugin มอบหน่วยความจำถาวรที่ค้นหาได้ให้ Claude Code — ทำให้ทุกเซสชันต่อยอดจากเซสชันก่อนหน้า
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.vi.md
+++ b/README.vi.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### Các phiên lập trình AI của bạn xứng đáng có bộ nhớ.
 
-MeMesh mang đến cho Claude Code bộ nhớ bền vững, có thể tìm kiếm — để mỗi phiên làm việc đều kế thừa từ phiên trước.
+MeMesh Plugin mang đến cho Claude Code bộ nhớ bền vững, có thể tìm kiếm — để mỗi phiên làm việc đều kế thừa từ phiên trước.
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,11 +2,11 @@
 
 <img src="https://img.shields.io/badge/%F0%9F%A7%A0-MeMesh-blueviolet?style=for-the-badge" alt="MeMesh" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### 你的 AI 编程会话值得拥有记忆。
 
-MeMesh 为 Claude Code 提供持久的、可搜索的记忆 — 让每次会话都能承接上次的成果。
+MeMesh Plugin 为 Claude Code 提供持久的、可搜索的记忆 — 让每次会话都能承接上次的成果。
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -228,7 +228,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant U as 你（在 Claude Code 中）
-    participant M as MeMesh MCP
+    participant M as MeMesh Plugin
     participant KG as 知識圖譜
     participant E as 嵌入模型（ONNX）
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,11 +2,11 @@
 
 <img src="docs/images/memesh-logo.svg" alt="MeMesh" width="80" />
 
-# MeMesh
+# MeMesh Plugin
 
 ### 你的 AI 程式開發應該有記憶。
 
-MeMesh 賦予 Claude Code 持久、可搜尋的記憶 — 讓每次對話都能延續上一次的成果。
+MeMesh Plugin 賦予 Claude Code 持久、可搜尋的記憶 — 讓每次對話都能延續上一次的成果。
 
 [![npm version](https://img.shields.io/npm/v/@pcircle/memesh?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@pcircle/memesh)
 [![Downloads](https://img.shields.io/npm/dm/@pcircle/memesh?style=flat-square&color=blue)](https://www.npmjs.com/package/@pcircle/memesh)

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,6 +1,6 @@
 # Accessibility Guide
 
-MeMesh is committed to providing an accessible experience for all users, including those using assistive technologies.
+MeMesh Plugin is committed to providing an accessible experience for all users, including those using assistive technologies.
 
 ## Screen Reader Support
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# MeMesh Architecture
+# MeMesh Plugin Architecture
 
 **Version**: 2.10.0
 **Last Updated**: 2026-03-08
@@ -8,7 +8,7 @@
 
 ## Overview
 
-MeMesh is a Model Context Protocol (MCP) server that enhances Claude Code with persistent memory, context-aware task execution, and knowledge management capabilities. It follows a layered architecture designed for extensibility, performance, and reliability.
+MeMesh Plugin is a Model Context Protocol (MCP) server that enhances Claude Code with persistent memory, context-aware task execution, and knowledge management capabilities. It follows a layered architecture designed for extensibility, performance, and reliability.
 
 ## Architecture Diagram
 
@@ -39,8 +39,7 @@ MeMesh is a Model Context Protocol (MCP) server that enhances Claude Code with p
 │  │  ├─ MemorySearchEngine (search/filter/rank/dedup)    │   │
 │  │  ├─ ProjectAutoTracker                               │   │
 │  │  ├─ ProactiveRecaller (session/test/error triggers)   │   │
-│  │  ├─ MistakePatternEngine                             │   │
-│  │  └─ AutoTagger                                       │   │
+│  │  └─ MistakePatternEngine                             │   │
 │  └──────────────────────────────────────────────────────┘   │
 │  ┌──────────────────────────────────────────────────────┐   │
 │  │  Knowledge Graph (src/knowledge-graph/)              │   │
@@ -127,7 +126,7 @@ MeMesh is a Model Context Protocol (MCP) server that enhances Claude Code with p
 - Content-based query filtering (substring match)
 - Search filter application (time range, importance, type, limit)
 - Result deduplication by content hash
-- Relevance ranking via SmartMemoryQuery delegation
+- Relevance ranking (multi-factor scoring: exact match, tag match, TF, recency)
 
 #### ProjectAutoTracker
 - Automatic tracking of project context
@@ -145,11 +144,6 @@ MeMesh is a Model Context Protocol (MCP) server that enhances Claude Code with p
 - Learns from user corrections
 - Detects recurring mistakes
 - Suggests improvements
-
-#### AutoTagger
-- Automatic tag generation for memories
-- Category detection
-- Relevance scoring
 
 **Data Flow**:
 ```

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -1,5 +1,5 @@
 # Best Practices
-## Effective Workflows for MeMesh
+## Effective Workflows for MeMesh Plugin
 
 This guide provides proven workflows and best practices for using MeMesh effectively in your daily development work.
 

--- a/docs/CLI_CONFIG_COMMANDS.md
+++ b/docs/CLI_CONFIG_COMMANDS.md
@@ -1,4 +1,4 @@
-# MeMesh Configuration Management
+# MeMesh Plugin Configuration Management
 
 The `memesh config` command provides utilities for managing your MeMesh configuration.
 

--- a/docs/CLI_PARAMETERS.md
+++ b/docs/CLI_PARAMETERS.md
@@ -1,6 +1,6 @@
 # CLI Parameters Reference
 
-Complete reference for all MeMesh CLI commands and their parameters.
+Complete reference for all MeMesh Plugin CLI commands and their parameters.
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -64,7 +64,7 @@ Recall project memory - past decisions, architecture choices, bug fixes, and pat
 **Parameters:**
 - `query` (required): What to search for
 - `limit` (optional): Max number of results (1-50, default: 10)
-- `mode` (optional): Search mode — `fts5` (keyword), `semantic` (AI similarity), `hybrid` (both combined). Default: `hybrid`
+- `mode` (optional): Search mode — `keyword` (exact match), `semantic` (AI similarity), `hybrid` (both combined). Default: `hybrid`
 - `matchThreshold` (optional): Minimum match score (0-1). Higher values return fewer but more relevant results. Default: 0.3
 - `allProjects` (optional): Search across ALL projects, not just the current one. Default: false
 
@@ -229,7 +229,7 @@ Internal hook event ingestion for workflow automation and memory tracking (auto-
 
 Record errors and mistakes for learning and prevention.
 
-**Aliases:** `record-mistake` (deprecated, will be removed in v3.0.0)
+**Aliases:** `buddy-record-mistake`
 
 **Input Schema:**
 ```json
@@ -272,7 +272,7 @@ Create knowledge entities with explicit relationships for fine-grained control o
   "entities": "array (required) - Array of entity objects",
   "entity.name": "string (required) - Unique entity name",
   "entity.entityType": "string (required) - Entity type",
-  "entity.observations": "array (optional) - Array of observation strings",
+  "entity.observations": "array (required) - Array of observation strings",
   "entity.tags": "array (optional) - Array of tag strings"
 }
 ```
@@ -303,7 +303,7 @@ View session metrics and tool usage statistics.
 **Input Schema:**
 ```json
 {
-  "period": "string (optional) - Time period: 'session' | 'day' | 'week' (default: 'session')"
+  "section": "string (optional) - Which metrics section: 'all' | 'session' | 'routing' | 'memory' (default: 'all')"
 }
 ```
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
-# MeMesh Commands Reference
+# MeMesh Plugin Commands Reference
 
-Complete reference for all MeMesh commands and tools.
+Complete reference for all MeMesh Plugin commands and tools.
 
 **Version**: 2.10.0
 **Last Updated**: 2026-03-08

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to MeMesh
+# Contributing to MeMesh Plugin
 
-**Welcome! We're excited that you're interested in contributing to MeMesh.**
+**Welcome! We're excited that you're interested in contributing to MeMesh Plugin.**
 
 This document provides guidelines for contributing code, documentation, bug reports, and feature requests.
 

--- a/docs/COWORK_SUPPORT.md
+++ b/docs/COWORK_SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## Current Status: Partial Support (Cloud-Only Mode)
 
-MeMesh plugin can run in **Claude Desktop Cowork** environments, but with limited functionality due to native module restrictions in the Cowork sandbox.
+MeMesh Plugin can run in **Claude Desktop Cowork** environments, but with limited functionality due to native module restrictions in the Cowork sandbox.
 
 ### ✅ What Works
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide covers the day-to-day development workflow for MeMesh contributors. For contribution guidelines and release processes, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+This guide covers the day-to-day development workflow for MeMesh Plugin contributors. For contribution guidelines and release processes, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Table of Contents
 

--- a/docs/ERROR_REFERENCE.md
+++ b/docs/ERROR_REFERENCE.md
@@ -1,6 +1,6 @@
 # Error Reference
 
-Complete reference of MeMesh error types, codes, and solutions.
+Complete reference of MeMesh Plugin error types, codes, and solutions.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,12 +1,12 @@
-# Getting Started with MeMesh
+# Getting Started with MeMesh Plugin
 
 **Install Time**: 2 minutes • **First Memory**: 30 seconds • **Ready to Code**: Immediately
 
 ---
 
-## What is MeMesh?
+## What is MeMesh Plugin?
 
-**MeMesh gives Claude Code a persistent memory.** Simple as that.
+**MeMesh Plugin gives Claude Code a persistent memory.** Simple as that.
 
 Every project you work on, every decision you make, every bug you fix—Claude remembers it all. No more re-explaining your architecture every session. No more "As I mentioned earlier..." No more starting from scratch.
 

--- a/docs/LANDING_PAGE.md
+++ b/docs/LANDING_PAGE.md
@@ -1,4 +1,4 @@
-# MeMesh — Searchable Project Memory for Claude Code
+# MeMesh Plugin — Searchable Project Memory for Claude Code
 
 > Remember decisions, patterns, and context — across every session.
 

--- a/docs/QUICK_INSTALL.md
+++ b/docs/QUICK_INSTALL.md
@@ -1,6 +1,6 @@
 # Quick Install Guide
 
-Get MeMesh up and running in under 2 minutes!
+Get MeMesh Plugin up and running in under 2 minutes!
 
 ---
 
@@ -76,14 +76,12 @@ When you install MeMesh, you get access to:
 2. **buddy-remember** - Project memory recall with semantic search
 3. **buddy-help** - Command documentation and help
 
-**MeMesh Tools (4 tools):**
-4. **memesh-record-mistake** - Error recording for continuous learning (⚠️ `buddy-record-mistake` deprecated)
-5. **memesh-create-entities** - Create and store knowledge entities (⚠️ `create-entities` deprecated)
-6. **memesh-hook-tool-use** - Hook event processing (⚠️ `hook-tool-use` deprecated)
-7. **memesh-generate-tests** - Automatic test generation (⚠️ `generate-tests` deprecated)
-
-**Cloud Sync (1 tool):**
-8. **memesh-cloud-sync** - Sync memories to MeMesh Cloud (optional)
+**MeMesh Tools (5 tools):**
+4. **memesh-record-mistake** - Record mistakes for continuous learning (⚠️ `buddy-record-mistake` deprecated)
+5. **memesh-create-entities** - Create knowledge entities with auto-relations (⚠️ `create-entities` deprecated)
+6. **memesh-hook-tool-use** - Process tool execution events (⚠️ `hook-tool-use` deprecated)
+7. **memesh-generate-tests** - Generate test cases from specs or code (⚠️ `generate-tests` deprecated)
+8. **memesh-metrics** - View session metrics and memory status
 
 ### Core Features
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,7 +1,7 @@
 # Quick Start Guide
-## Get Started with MeMesh in 5 Minutes
+## Get Started with MeMesh Plugin in 5 Minutes
 
-Welcome to MeMesh! This guide will help you set up and start using MeMesh in less than 5 minutes.
+Welcome to MeMesh Plugin! This guide will help you set up and start using MeMesh Plugin in less than 5 minutes.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
-# MeMesh Documentation
+# MeMesh Plugin Documentation
 
-Welcome to the MeMesh documentation.
+Welcome to the MeMesh Plugin documentation.
 
 ---
 
 ## Getting Started
 - **[Getting Started](./GETTING_STARTED.md)** — New users start here
 - **[Quick Install](./QUICK_INSTALL.md)** — 2-minute setup
-- **[Quick Start](./QUICK_START.md)** — First 5 minutes with MeMesh
+- **[Quick Start](./QUICK_START.md)** — First 5 minutes with MeMesh Plugin
 - **[Upgrade Guide](./UPGRADE.md)** — Upgrading from a previous version
 
 ## User Reference

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,6 +1,6 @@
-# MeMesh Release Process
+# MeMesh Plugin Release Process
 
-This document describes the complete release process for MeMesh, including versioning, changelog maintenance, and automated publishing.
+This document describes the complete release process for MeMesh Plugin, including versioning, changelog maintenance, and automated publishing.
 
 ## Overview
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,6 +1,6 @@
-# 🔄 Upgrade Guide: Claude Code Buddy → MeMesh
+# 🔄 Upgrade Guide: Claude Code Buddy → MeMesh Plugin
 
-> **Important**: MeMesh was previously known as "Claude Code Buddy (CCB)". This guide helps existing users upgrade safely without losing any data.
+> **Important**: MeMesh Plugin was previously known as "Claude Code Buddy (CCB)". This guide helps existing users upgrade safely without losing any data.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,7 +1,7 @@
 # User Guide
-## Complete Reference for MeMesh
+## Complete Reference for MeMesh Plugin
 
-Welcome to the complete MeMesh User Guide! This guide provides detailed information about all commands, features, and workflows.
+Welcome to the complete MeMesh Plugin User Guide! This guide provides detailed information about all commands, features, and workflows.
 
 ---
 
@@ -24,9 +24,9 @@ Welcome to the complete MeMesh User Guide! This guide provides detailed informat
 
 ## Introduction
 
-### What is MeMesh?
+### What is MeMesh Plugin?
 
-MeMesh is a persistent memory plugin for Claude Code that helps you:
+MeMesh Plugin is a persistent memory plugin for Claude Code that helps you:
 
 - **Remember across sessions**: Persistent knowledge graph storage
 - **Execute tasks with context**: Memory-enhanced task execution
@@ -35,10 +35,10 @@ MeMesh is a persistent memory plugin for Claude Code that helps you:
 
 ### Architecture Overview
 
-MeMesh runs as a local-first MCP server:
+MeMesh Plugin runs as a local-first MCP server:
 
 ```
-Claude Code ──stdio──► MeMesh MCP Server
+Claude Code ──stdio──► MeMesh Plugin
                               │
                     ┌─────────┼─────────┐
                     ▼         ▼         ▼

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -23,10 +23,10 @@
 7. [System Tools](#system-tools)
    - [memesh-generate-tests](#memesh-generate-tests)
    - [memesh-metrics](#memesh-metrics)
-7. [Data Models](#data-models)
-8. [Error Reference](#error-reference)
-9. [Integration Examples](#integration-examples)
-10. [Rate Limits & Performance](#rate-limits--performance)
+8. [Data Models](#data-models)
+9. [Error Reference](#error-reference)
+10. [Integration Examples](#integration-examples)
+11. [Rate Limits & Performance](#rate-limits--performance)
 
 ---
 
@@ -146,8 +146,7 @@ MeMesh provides 8 MCP tools organized into three categories:
   "properties": {
     "task": {
       "type": "string",
-      "description": "Task description for MeMesh to execute with memory context",
-      "minLength": 1
+      "description": "Task description to analyze and enrich (e.g., 'setup authentication', 'fix login bug')"
     }
   },
   "required": ["task"]
@@ -387,15 +386,28 @@ Extracted metadata:
   "properties": {
     "query": {
       "type": "string",
-      "description": "What to remember/recall from project memory",
-      "minLength": 1
+      "description": "Search query (natural language supported for semantic search)"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["semantic", "keyword", "hybrid"],
+      "description": "Search mode: semantic (AI similarity), keyword (exact match), hybrid (both combined). Default: hybrid"
     },
     "limit": {
       "type": "number",
-      "description": "Maximum number of memories to retrieve",
-      "default": 5,
+      "description": "Maximum number of results to return (1-50, default: 10)",
       "minimum": 1,
       "maximum": 50
+    },
+    "matchThreshold": {
+      "type": "number",
+      "description": "Minimum match score (0-1). Higher values return fewer but more relevant results. Default: 0.3",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "allProjects": {
+      "type": "boolean",
+      "description": "Search across all projects (default: false, searches only current project + global memories)"
     }
   },
   "required": ["query"]
@@ -406,8 +418,11 @@ Extracted metadata:
 
 | Parameter | Type | Required | Default | Description | Example |
 |-----------|------|----------|---------|-------------|---------|
-| `query` | string | Yes | - | Search query or information to store | "why did we choose PostgreSQL?" |
-| `limit` | number | No | 5 | Max number of results (1-50) | 10 |
+| `query` | string | Yes | - | Search query (natural language supported) | "why did we choose PostgreSQL?" |
+| `mode` | string | No | hybrid | Search mode: `semantic`, `keyword`, `hybrid` | "keyword" |
+| `limit` | number | No | 10 | Max number of results (1-50) | 20 |
+| `matchThreshold` | number | No | 0.3 | Minimum match score (0-1) | 0.5 |
+| `allProjects` | boolean | No | false | Search across all projects | true |
 
 #### Response Format
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,4 +1,4 @@
-# MeMesh MCP Server - API Reference
+# MeMesh Plugin - API Reference
 
 **Version**: 2.10.0
 **Last Updated**: 2026-03-08
@@ -17,12 +17,12 @@
    - [buddy-help](#buddy-help)
 5. [Knowledge Graph Tools](#knowledge-graph-tools)
    - [memesh-create-entities](#memesh-create-entities)
-   - [recall-memory](#recall-memory)
-   - [add-observations](#add-observations)
-   - [create-relations](#create-relations)
-6. [System Tools](#system-tools)
-   - [health-check](#health-check)
+6. [Learning & Automation Tools](#learning--automation-tools)
+   - [memesh-record-mistake](#memesh-record-mistake)
+   - [memesh-hook-tool-use](#memesh-hook-tool-use)
+7. [System Tools](#system-tools)
    - [memesh-generate-tests](#memesh-generate-tests)
+   - [memesh-metrics](#memesh-metrics)
 7. [Data Models](#data-models)
 8. [Error Reference](#error-reference)
 9. [Integration Examples](#integration-examples)
@@ -32,7 +32,7 @@
 
 ## Introduction
 
-MeMesh is an MCP (Model Context Protocol) server that provides persistent memory management, context-aware task execution, and knowledge graph capabilities for Claude Code. This API reference documents all available MCP tools, their parameters, responses, and usage patterns.
+MeMesh Plugin is an MCP (Model Context Protocol) server that provides persistent memory management, context-aware task execution, and knowledge graph capabilities for Claude Code. This API reference documents all available MCP tools, their parameters, responses, and usage patterns.
 
 **Key Features**:
 - Context-aware task execution with memory integration
@@ -47,7 +47,7 @@ Claude Code CLI
       ↓
 MCP Protocol
       ↓
-MeMesh MCP Server
+MeMesh Plugin
       ↓
    ┌──────┴──────┐
    ↓             ↓
@@ -58,9 +58,9 @@ Router      Knowledge Graph
 
 ## Authentication & Connection
 
-MeMesh is a Claude Code Plugin. The MCP server is auto-managed via the plugin's `.mcp.json` file — no manual configuration of `~/.claude/mcp_settings.json` is needed.
+MeMesh Plugin is a Claude Code Plugin. The MCP server is auto-managed via the plugin's `.mcp.json` file — no manual configuration of `~/.claude/mcp_settings.json` is needed.
 
-Simply install MeMesh and restart Claude Code. The plugin system handles MCP server registration automatically.
+Simply install MeMesh Plugin and restart Claude Code. The plugin system handles MCP server registration automatically.
 
 **If auto-configuration fails**, run `memesh setup` to reconfigure.
 
@@ -107,17 +107,21 @@ MeMesh provides 8 MCP tools organized into three categories:
 
 | Tool | Purpose | Complexity |
 |------|---------|-----------|
-| `memesh-create-entities` | Create knowledge entities with relationships | Advanced |
-| `recall-memory` | Low-level memory search with filters | Advanced |
-| `add-observations` | Add observations to existing entities | Advanced |
-| `create-relations` | Link entities with typed relationships | Advanced |
+| `memesh-create-entities` | Create knowledge entities with auto-relations | Advanced |
+
+### Learning & Automation Tools
+
+| Tool | Purpose | Complexity |
+|------|---------|-----------|
+| `memesh-record-mistake` | Record mistakes for continuous learning | Medium |
+| `memesh-hook-tool-use` | Process tool execution events (auto-triggered) | Internal |
 
 ### System Tools
 
 | Tool | Purpose | Complexity |
 |------|---------|-----------|
-| `health-check` | Monitor system health | Simple |
-| `memesh-generate-tests` | Generate test cases | Medium |
+| `memesh-generate-tests` | Generate test cases from specs or code | Medium |
+| `memesh-metrics` | View session metrics and memory status | Simple |
 
 ---
 
@@ -1029,16 +1033,21 @@ Becomes:
 
 ---
 
-### recall-memory
+---
 
-**Purpose**: Low-level memory search with advanced filtering options.
+## Learning & Automation Tools
+
+### memesh-record-mistake
+
+**Purpose**: Record AI mistakes for learning and prevention — enables systematic improvement from user feedback.
+
+**Aliases**: `buddy-record-mistake` (deprecated, will be removed in v3.0.0)
 
 **Use Cases**:
-- Advanced memory searches with filters
-- Time-range based queries
-- Tag-filtered searches
-- Entity type filtering
-- Programmatic memory access
+- User explicitly corrects AI behavior or approach
+- Violated a documented procedure or guideline
+- Made incorrect assumptions instead of asking
+- Skipped validation step and caused problems
 
 #### Input Schema
 
@@ -1046,135 +1055,91 @@ Becomes:
 {
   "type": "object",
   "properties": {
-    "limit": {
-      "type": "number",
-      "description": "Maximum number of memories to return",
-      "default": 10
-    },
-    "query": {
+    "action": {
       "type": "string",
-      "description": "Optional search query to filter memories"
+      "description": "What action the AI took (the mistake)"
+    },
+    "errorType": {
+      "type": "string",
+      "description": "Error classification",
+      "enum": [
+        "procedure-violation",
+        "workflow-skip",
+        "assumption-error",
+        "validation-skip",
+        "responsibility-lack",
+        "firefighting",
+        "dependency-miss",
+        "integration-error",
+        "deployment-error"
+      ]
+    },
+    "userCorrection": {
+      "type": "string",
+      "description": "User's correction/feedback"
+    },
+    "correctMethod": {
+      "type": "string",
+      "description": "What should have been done instead"
+    },
+    "impact": {
+      "type": "string",
+      "description": "Impact of the mistake"
+    },
+    "preventionMethod": {
+      "type": "string",
+      "description": "How to prevent this in the future"
+    },
+    "relatedRule": {
+      "type": "string",
+      "description": "Related rule/guideline (optional)"
+    },
+    "context": {
+      "type": "object",
+      "description": "Additional context (optional)"
     }
-  }
+  },
+  "required": ["action", "errorType", "userCorrection", "correctMethod", "impact", "preventionMethod"]
 }
 ```
 
 #### Parameters
 
-| Parameter | Type | Required | Default | Description | Example |
-|-----------|------|----------|---------|-------------|---------|
-| `limit` | number | No | 10 | Max results to return | 20 |
-| `query` | string | No | - | Search query filter | "authentication" |
+| Parameter | Type | Required | Description | Example |
+|-----------|------|----------|-------------|---------|
+| `action` | string | Yes | What action the AI took | "Edited file without reading first" |
+| `errorType` | string | Yes | Error classification (see enum) | "procedure-violation" |
+| `userCorrection` | string | Yes | User's correction/feedback | "Must read file before editing" |
+| `correctMethod` | string | Yes | What should have been done | "Use Read tool first" |
+| `impact` | string | Yes | Impact of the mistake | "Broke file indentation" |
+| `preventionMethod` | string | Yes | How to prevent in future | "ALWAYS Read before Edit" |
+| `relatedRule` | string | No | Related rule/guideline | "READ_BEFORE_EDIT" |
+| `context` | object | No | Additional context | `{}` |
 
-#### Response Format
-
-```typescript
-{
-  memories: Array<{
-    type: string,           // Entity type
-    observations: string[], // Array of observations
-    timestamp?: string      // ISO timestamp
-  }>
-}
-```
-
-#### Examples
-
-**Example 1: Recent Work Recall**
+#### Example
 
 Request:
 ```json
 {
-  "limit": 10
+  "action": "Edited ServerInitializer.ts without reading file first",
+  "errorType": "procedure-violation",
+  "userCorrection": "Must read file before editing - broke indentation",
+  "correctMethod": "Use Read tool first to see exact content and formatting, then Edit",
+  "impact": "Broke file indentation, required re-edit, wasted user time",
+  "preventionMethod": "ALWAYS invoke Read tool before Edit tool - no exceptions",
+  "relatedRule": "READ_BEFORE_EDIT (Anti-Hallucination Protocol)"
 }
 ```
-
-Response:
-```json
-{
-  "memories": [
-    {
-      "type": "code_change",
-      "observations": [
-        "Updated authentication middleware",
-        "Added JWT validation"
-      ],
-      "timestamp": "2026-02-03T10:00:00Z"
-    },
-    {
-      "type": "test_result",
-      "observations": [
-        "All tests passing: 245/245",
-        "Coverage: 87%"
-      ],
-      "timestamp": "2026-02-03T09:45:00Z"
-    }
-  ]
-}
-```
-
-**Example 2: Filtered Search**
-
-Request:
-```json
-{
-  "limit": 5,
-  "query": "database"
-}
-```
-
-Response:
-```json
-{
-  "memories": [
-    {
-      "type": "decision",
-      "observations": [
-        "Chose PostgreSQL for production",
-        "Better JSON support than MySQL"
-      ],
-      "timestamp": "2026-02-01T14:30:00Z"
-    }
-  ]
-}
-```
-
-#### Comparison with buddy-remember
-
-| Feature | recall-memory | buddy-remember |
-|---------|--------------|----------------|
-| Complexity | Advanced | Simple |
-| Response format | Raw JSON | Formatted text |
-| Auto-detection | No | Yes (storage vs recall) |
-| Filtering | Basic (query/limit) | Automatic semantic search |
-| Use case | Programmatic access | User-friendly interface |
-
-#### Best Practices
-
-✅ **Use recall-memory when**:
-- Building programmatic tools
-- Need raw JSON responses
-- Simple filtering is sufficient
-- Integrating with other systems
-
-✅ **Use buddy-remember when**:
-- Interactive use in Claude Code
-- Need formatted responses
-- Want auto-storage detection
-- Prefer user-friendly interface
 
 ---
 
-### add-observations
+### memesh-hook-tool-use
 
-**Purpose**: Add new observations to existing entities in the knowledge graph.
+**Purpose**: Process tool execution events from Claude Code CLI for workflow automation.
 
-**Use Cases**:
-- Update entities with new information
-- Add notes to decisions
-- Track changes to features
-- Document additional findings
-- Append investigation results
+**Aliases**: `hook-tool-use` (deprecated, will be removed in v3.0.0)
+
+**Note**: This tool is auto-triggered by Claude Code hooks. Do not call manually.
 
 #### Input Schema
 
@@ -1182,651 +1147,49 @@ Response:
 {
   "type": "object",
   "properties": {
-    "observations": {
-      "type": "array",
-      "description": "Array of observations to add",
-      "items": {
-        "type": "object",
-        "properties": {
-          "entityName": {
-            "type": "string",
-            "description": "Name of entity to update"
-          },
-          "contents": {
-            "type": "array",
-            "items": { "type": "string" },
-            "description": "Observations to add"
-          }
-        },
-        "required": ["entityName", "contents"]
-      }
+    "toolName": {
+      "type": "string",
+      "description": "Tool name executed by Claude Code (e.g., 'Write', 'Edit', 'Bash')"
+    },
+    "arguments": {
+      "type": "object",
+      "description": "Tool arguments payload (tool-specific)"
+    },
+    "success": {
+      "type": "boolean",
+      "description": "Whether the tool execution succeeded"
+    },
+    "duration": {
+      "type": "number",
+      "description": "Execution duration in milliseconds (optional)"
+    },
+    "tokensUsed": {
+      "type": "number",
+      "description": "Tokens used by the tool call (optional)"
+    },
+    "output": {
+      "type": "string",
+      "description": "Tool output (optional)"
     }
   },
-  "required": ["observations"]
+  "required": ["toolName", "success"]
 }
 ```
 
 #### Parameters
 
-| Field | Type | Required | Description | Example |
-|-------|------|----------|-------------|---------|
-| `observations` | array | Yes | Array of observation objects | See examples |
-| `observations[].entityName` | string | Yes | Entity to update | "PostgreSQL Decision" |
-| `observations[].contents` | array | Yes | Observations to add | ["Added replication", "Performance improved 40%"] |
-
-#### Response Format
-
-```typescript
-{
-  updated: string[],        // Names of updated entities
-  count: number,            // Number updated
-  notFound?: string[],      // Entities not found
-  errors?: Array<{          // Errors if any
-    entityName: string,
-    error: string
-  }>
-}
-```
-
-#### Examples
-
-**Example 1: Update Single Entity**
-
-Request:
-```json
-{
-  "observations": [
-    {
-      "entityName": "PostgreSQL Database Choice 2026-02-03",
-      "contents": [
-        "Added read replicas for scalability",
-        "Performance improved by 40%",
-        "Currently handling 1M requests/day"
-      ]
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "updated": ["PostgreSQL Database Choice 2026-02-03"],
-  "count": 1
-}
-```
-
-**Example 2: Update Multiple Entities**
-
-Request:
-```json
-{
-  "observations": [
-    {
-      "entityName": "User Authentication Feature",
-      "contents": [
-        "Added OAuth support for GitHub",
-        "Social login working in production"
-      ]
-    },
-    {
-      "entityName": "Authentication API Endpoints",
-      "contents": [
-        "POST /api/v1/auth/oauth/github added",
-        "Handles callback and token exchange"
-      ]
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "updated": [
-    "User Authentication Feature",
-    "Authentication API Endpoints"
-  ],
-  "count": 2
-}
-```
-
-**Example 3: Entity Not Found**
-
-Request:
-```json
-{
-  "observations": [
-    {
-      "entityName": "Non-existent Entity",
-      "contents": ["New observation"]
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "updated": [],
-  "count": 0,
-  "notFound": ["Non-existent Entity"]
-}
-```
-
-#### Concurrency Behavior
-
-**Note**: Uses get-then-update pattern:
-- Sufficient for single-user CLI usage
-- Not suitable for concurrent access
-- Uses `INSERT OR REPLACE` for atomic updates at SQL level
-- Sequential processing minimizes race condition window
-
-#### Best Practices
-
-✅ **Do**:
-- Add meaningful observations
-- Include timestamps in content if relevant
-- Update entities incrementally as you learn
-- Check entity exists first (use recall-memory)
-
-❌ **Don't**:
-- Add duplicate observations
-- Use for creating new entities (use memesh-create-entities)
-- Expect full ACID transactions across multiple entities
-
-#### Error Responses
-
-```typescript
-// Entity not found
-{
-  updated: [],
-  count: 0,
-  notFound: ["Entity Name"]
-}
-
-// Update error
-{
-  updated: ["Entity 1"],
-  count: 1,
-  errors: [
-    {
-      entityName: "Entity 2",
-      error: "Database write failed"
-    }
-  ]
-}
-
-// Validation error
-{
-  error: "Validation failed: entityName is required",
-  code: "VALIDATION_FAILED"
-}
-```
-
----
-
-### create-relations
-
-**Purpose**: Create typed relationships between entities in the knowledge graph.
-
-**Use Cases**:
-- Link decisions to implementations
-- Show bug causes and fixes
-- Document dependencies
-- Map feature relationships
-- Build knowledge graph structure
-
-#### Input Schema
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "relations": {
-      "type": "array",
-      "description": "Array of relations to create",
-      "items": {
-        "type": "object",
-        "properties": {
-          "from": {
-            "type": "string",
-            "description": "Source entity name"
-          },
-          "to": {
-            "type": "string",
-            "description": "Target entity name"
-          },
-          "relationType": {
-            "type": "string",
-            "description": "Type of relationship"
-          },
-          "metadata": {
-            "type": "object",
-            "description": "Optional metadata"
-          }
-        },
-        "required": ["from", "to", "relationType"]
-      }
-    }
-  },
-  "required": ["relations"]
-}
-```
-
-#### Parameters
-
-| Field | Type | Required | Description | Example |
-|-------|------|----------|-------------|---------|
-| `relations` | array | Yes | Array of relation objects | See examples |
-| `relations[].from` | string | Yes | Source entity name | "User Auth Feature" |
-| `relations[].to` | string | Yes | Target entity name | "JWT Decision" |
-| `relations[].relationType` | string | Yes | Relationship type (see types below) | "depends_on" |
-| `relations[].metadata` | object | No | Custom metadata | { "strength": "high" } |
-
-#### Relation Types
-
-| Type | Description | Direction | Example |
-|------|-------------|-----------|---------|
-| `caused_by` | A caused by B | A ← B | Bug caused_by code change |
-| `enabled_by` | A enabled by B | A ← B | Feature enabled_by library |
-| `follows_pattern` | A follows pattern from B | A → B | Code follows_pattern best practice |
-| `solves` | A solves B | A → B | Fix solves bug |
-| `replaced_by` | A replaced by B | A → B | Old API replaced_by new API |
-| `depends_on` | A depends on B | A → B | Feature depends_on database |
-| `similar_to` | A similar to B | A ↔ B | Bug similar_to previous bug |
-| `evolved_from` | A evolved from B | A ← B | Feature evolved_from prototype |
-
-#### Response Format
-
-```typescript
-{
-  created: Array<{
-    from: string,
-    to: string,
-    type: string
-  }>,
-  count: number,
-  missingEntities?: string[],  // Entities that don't exist
-  errors?: Array<{
-    from: string,
-    to: string,
-    error: string
-  }>
-}
-```
-
-#### Examples
-
-**Example 1: Feature Dependencies**
-
-Request:
-```json
-{
-  "relations": [
-    {
-      "from": "User Authentication Feature",
-      "to": "PostgreSQL Database Choice 2026-02-03",
-      "relationType": "depends_on",
-      "metadata": {
-        "reason": "Stores user credentials and sessions"
-      }
-    },
-    {
-      "from": "User Authentication Feature",
-      "to": "JWT Library Decision",
-      "relationType": "enabled_by",
-      "metadata": {
-        "library": "jsonwebtoken"
-      }
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "created": [
-    {
-      "from": "User Authentication Feature",
-      "to": "PostgreSQL Database Choice 2026-02-03",
-      "type": "depends_on"
-    },
-    {
-      "from": "User Authentication Feature",
-      "to": "JWT Library Decision",
-      "type": "enabled_by"
-    }
-  ],
-  "count": 2
-}
-```
-
-**Example 2: Bug Fix Relationships**
-
-Request:
-```json
-{
-  "relations": [
-    {
-      "from": "Session Timeout Bug",
-      "to": "Cookie Domain Misconfiguration",
-      "relationType": "caused_by"
-    },
-    {
-      "from": "Session Config Update",
-      "to": "Session Timeout Bug",
-      "relationType": "solves"
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "created": [
-    {
-      "from": "Session Timeout Bug",
-      "to": "Cookie Domain Misconfiguration",
-      "type": "caused_by"
-    },
-    {
-      "from": "Session Config Update",
-      "to": "Session Timeout Bug",
-      "type": "solves"
-    }
-  ],
-  "count": 2
-}
-```
-
-**Example 3: Missing Entities**
-
-Request:
-```json
-{
-  "relations": [
-    {
-      "from": "Existing Entity",
-      "to": "Non-existent Entity",
-      "relationType": "depends_on"
-    }
-  ]
-}
-```
-
-Response:
-```json
-{
-  "created": [],
-  "count": 0,
-  "missingEntities": ["Non-existent Entity"]
-}
-```
-
-#### Validation
-
-Both source and target entities must exist before creating a relation. The tool verifies entity existence before creating relationships.
-
-#### Best Practices
-
-✅ **Do**:
-- Create entities before relations
-- Use meaningful relation types
-- Add metadata for context
-- Document why relationships exist
-- Build relationships incrementally
-
-❌ **Don't**:
-- Create circular dependencies without reason
-- Use generic relation types (be specific)
-- Forget to verify entities exist
-- Create duplicate relations
-
-#### Use Cases by Relation Type
-
-**`depends_on`**: Technical dependencies
-- Feature → Library
-- Service → Database
-- Component → Configuration
-
-**`caused_by`**: Root cause analysis
-- Bug → Code Change
-- Issue → Configuration Error
-- Failure → Missing Dependency
-
-**`solves`**: Problem resolution
-- Fix → Bug
-- Workaround → Issue
-- Optimization → Performance Problem
-
-**`enabled_by`**: Enablement tracking
-- Feature → Technology Choice
-- Capability → Tool Integration
-- Improvement → Library Update
-
-**`follows_pattern`**: Pattern adoption
-- Implementation → Best Practice
-- Code → Design Pattern
-- Solution → Reference Implementation
-
-#### Error Responses
-
-```typescript
-// Missing entities
-{
-  created: [],
-  count: 0,
-  missingEntities: ["Entity A", "Entity B"]
-}
-
-// Partial success
-{
-  created: [{ from: "A", to: "B", type: "depends_on" }],
-  count: 1,
-  errors: [
-    {
-      from: "C",
-      to: "D",
-      error: "Database constraint violation"
-    }
-  ]
-}
-
-// Validation error
-{
-  error: "Validation failed: relationType is required",
-  code: "VALIDATION_FAILED"
-}
-```
+| Parameter | Type | Required | Description | Example |
+|-----------|------|----------|-------------|---------|
+| `toolName` | string | Yes | Tool executed by Claude Code | "Write" |
+| `success` | boolean | Yes | Whether execution succeeded | true |
+| `arguments` | object | No | Tool arguments payload | `{"file_path": "..."}` |
+| `duration` | number | No | Duration in milliseconds | 150 |
+| `tokensUsed` | number | No | Tokens used by tool call | 500 |
+| `output` | string | No | Tool output | "File written" |
 
 ---
 
 ## System Tools
-
-### health-check
-
-**Purpose**: Monitor MeMesh system health and component status.
-
-**Use Cases**:
-- Verify system is operational
-- Diagnose connection issues
-- Check database status
-- Monitor resource usage
-- Troubleshoot problems
-
-#### Input Schema
-
-```json
-{
-  "type": "object",
-  "properties": {}
-}
-```
-
-#### Parameters
-
-None. This tool requires no parameters.
-
-#### Response Format
-
-```typescript
-{
-  content: [
-    {
-      type: "text",
-      text: string  // Formatted health status
-    }
-  ]
-}
-```
-
-**Response Structure** (parsed from formatted text):
-- Overall status (healthy/degraded/unhealthy)
-- Component statuses
-  - Database
-  - Filesystem
-  - Memory
-- Uptime
-- Resource metrics
-
-#### Examples
-
-**Example 1: Healthy System**
-
-Request:
-```json
-{}
-```
-
-Response:
-```
-✓ HEALTH CHECK - HEALTHY
-
-System Status: All components operational
-
-────────────────────────────────────
-
-Components:
-  ✓ Database: healthy (5ms)
-  ✓ Filesystem: healthy (2ms)
-  ✓ Memory: healthy (98% available)
-
-────────────────────────────────────
-
-Metrics:
-  Uptime: 12h 34m
-  Total checks: 1,234
-  Last check: 2026-02-03T10:30:00Z
-
-Duration: 15ms
-```
-
-**Example 2: Degraded System**
-
-Response:
-```
-⚠ HEALTH CHECK - DEGRADED
-
-System Status: Some components experiencing issues
-
-────────────────────────────────────
-
-Components:
-  ✓ Database: healthy (5ms)
-  ⚠ Filesystem: degraded (High disk usage: 92%)
-  ✓ Memory: healthy (95% available)
-
-────────────────────────────────────
-
-Recommendations:
-  1. Check disk space and clean up old files
-  2. Consider increasing storage capacity
-
-Duration: 18ms
-```
-
-**Example 3: Unhealthy System**
-
-Response:
-```
-✗ HEALTH CHECK - UNHEALTHY
-
-System Status: Critical components unavailable
-
-────────────────────────────────────
-
-Components:
-  ✗ Database: unhealthy (Connection timeout)
-  ✓ Filesystem: healthy (3ms)
-  ✓ Memory: healthy (97% available)
-
-────────────────────────────────────
-
-Recommendations:
-  1. Restart MeMesh server
-  2. Check database file permissions
-  3. Verify MEMESH_DATA_DIR is accessible
-
-Duration: 5002ms
-```
-
-#### Health Status Levels
-
-| Status | Description | Action Required |
-|--------|-------------|-----------------|
-| Healthy | All components operational | None |
-| Degraded | Some components have warnings | Monitor, plan fixes |
-| Unhealthy | Critical components down | Immediate action |
-
-#### Component Checks
-
-**Database**:
-- SQLite connection test
-- Write/read verification
-- Query performance
-
-**Filesystem**:
-- Data directory accessibility
-- Disk space availability
-- File permissions
-
-**Memory**:
-- Available RAM
-- Usage trends
-- Resource limits
-
-#### Best Practices
-
-✅ **Use health-check when**:
-- First time setting up MeMesh
-- Troubleshooting connection issues
-- After system updates
-- Before important operations
-- Periodically to monitor health
-
-✅ **Interpret results**:
-- Healthy: All clear to proceed
-- Degraded: Note warnings, proceed with caution
-- Unhealthy: Fix issues before continuing
-
-#### Error Responses
-
-```typescript
-// Health check itself failed
-{
-  content: [
-    {
-      type: "text",
-      text: "Health check failed: timeout after 5000ms"
-    }
-  ]
-}
-```
-
----
 
 ### memesh-generate-tests
 
@@ -1971,6 +1334,49 @@ Adjust imports and syntax as needed for your framework.
 {
   error: "Provide either specification or code, not both",
   code: "VALIDATION_FAILED"
+}
+```
+
+---
+
+### memesh-metrics
+
+**Purpose**: View MeMesh session metrics, routing configuration, and memory status.
+
+#### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "section": {
+      "type": "string",
+      "enum": ["all", "session", "routing", "memory"],
+      "description": "Which metrics section to return (default: 'all')"
+    }
+  }
+}
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description | Example |
+|-----------|------|----------|---------|-------------|---------|
+| `section` | string | No | "all" | Which metrics section to return | "session" |
+
+#### Section Details
+
+- **all** (default): Returns everything below
+- **session**: Current session state — modified files, tested files, code review status
+- **routing**: Active model rules, planning enforcement, dry-run gate, recent audit log
+- **memory**: Knowledge graph size and status
+
+#### Example
+
+Request:
+```json
+{
+  "section": "memory"
 }
 ```
 
@@ -2447,11 +1853,10 @@ await createRelations({
 | `buddy-remember` (store) | 50-200ms | Simple database insert |
 | `buddy-remember` (search) | 100-500ms | Depends on graph size |
 | `memesh-create-entities` | 50-200ms per entity | Batch operations faster |
-| `recall-memory` | 100-300ms | Direct database query |
-| `add-observations` | 100-300ms | Get-then-update pattern |
-| `create-relations` | 150-400ms | Validates both entities first |
-| `health-check` | 10-100ms | All checks in parallel |
+| `memesh-record-mistake` | 50-200ms | Database insert |
+| `memesh-hook-tool-use` | 10-100ms | Event processing |
 | `memesh-generate-tests` | 1000-5000ms | Uses LLM sampling |
+| `memesh-metrics` | 10-100ms | Read-only aggregation |
 
 ### Rate Limits
 
@@ -2462,8 +1867,7 @@ await createRelations({
 
 **Best Practices**:
 - Batch entity creation when possible
-- Avoid excessive polling of health-check
-- Cache recall-memory results when appropriate
+- Cache buddy-remember results when appropriate
 - Use appropriate query limits
 
 ### Resource Usage
@@ -2482,19 +1886,18 @@ await createRelations({
 **CPU**:
 - Most operations: Low CPU usage
 - memesh-generate-tests: Medium CPU (LLM sampling)
-- health-check: Minimal CPU
+- memesh-metrics: Minimal CPU
 
 ### Optimization Tips
 
 ✅ **Optimize Performance**:
 - Batch memesh-create-entities operations
 - Use appropriate limit parameters
-- Avoid unnecessary health-checks
 - Cache buddy-remember searches
 - Clean up old entities periodically
 
 ✅ **Monitor Usage**:
-- Check health-check regularly
+- Use memesh-metrics to check memory status
 - Monitor database file size
 - Track operation latency
 - Review error rates
@@ -2530,6 +1933,6 @@ await createRelations({
 
 ---
 
-**MeMesh MCP Server** - Persistent memory and context-aware task execution for Claude Code
+**MeMesh Plugin** - Persistent memory and context-aware task execution for Claude Code
 
 *For questions or issues, please visit the GitHub repository or open an issue.*

--- a/docs/api/MEMORY_API.md
+++ b/docs/api/MEMORY_API.md
@@ -1,13 +1,12 @@
 # Memory API Reference
 
-Complete API documentation for MeMesh memory system.
+Complete API documentation for MeMesh Plugin memory system.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [UnifiedMemoryStore](#unifiedmemorystore)
-- [SmartMemoryQuery](#smartmemoryquery)
-- [AutoTagger](#autotagger)
+- [MemorySearchEngine](#memorysearchengine)
 - [AutoMemoryRecorder](#automemoryrecorder)
 - [Types](#types)
 - [Best Practices](#best-practices)
@@ -213,119 +212,48 @@ const deleted = await memoryStore.delete('unified-memory-123');
 
 ---
 
-## SmartMemoryQuery
+## MemorySearchEngine
 
-Context-aware memory search with relevance ranking.
+Search logic extracted from UnifiedMemoryStore. Handles content-based query filtering, search filter application, result deduplication, and relevance ranking.
 
-### Constructor
+### Usage
 
-```typescript
-import { SmartMemoryQuery } from '@pcircle/memesh/memory/SmartMemoryQuery';
+MemorySearchEngine is used internally by UnifiedMemoryStore. It is not instantiated directly — search operations are accessed through `UnifiedMemoryStore.search()`.
 
-const smartQuery = new SmartMemoryQuery();
-```
+### Search Scoring
 
-### Methods
-
-#### `search(query, memories, options?)`
-
-Search and rank memories by relevance.
-
-**Parameters:**
-- `query: string` - Search query
-- `memories: UnifiedMemory[]` - Memory set to search
-- `options?: SearchOptions & { techStack?: string[] }` - Search options
-
-**Returns:** `UnifiedMemory[]` - Ranked memories (highest score first)
-
-**Example:**
-
-```typescript
-const allMemories = await memoryStore.search('');
-const results = smartQuery.search('JWT authentication', allMemories, {
-  techStack: ['nodejs', 'express'],
-});
-
-// Results are ranked by relevance:
-// - Exact content match: +100 points
-// - Tag match: +50 per tag
-// - TF content scoring: up to +20
-// - Tech stack boost: 1.5x
-// - Importance multiplier
-// - Recency boost
-```
-
-**Scoring Formula:**
+MemorySearchEngine uses a **multi-factor scoring system**:
 
 ```
-score = (100 * exact_match + 50 * tag_matches + TF_score)
-      * tech_boost
-      * importance
-      * recency_boost
+Final Score = (Content Match + Tag Match + TF Score)
+              × Tech Stack Boost
+              × Importance
+              × Recency Boost
 ```
 
----
+**Scoring breakdown:**
+- **Exact content match**: +100 points
+- **Tag match**: +50 points per matching tag
+- **TF score**: 0-20 points based on term frequency
+- **Tech stack boost**: 1.5× if matches tech stack
+- **Importance**: 0.0-1.0 multiplier
+- **Recency boost**: 1.2× if <7 days, 1.1× if <30 days
 
-## AutoTagger
+### Features
 
-Intelligent tag generation from content.
+- Content-based query filtering (substring match)
+- Search filter application (time range, importance, type, limit)
+- Result deduplication by content hash
+- Relevance ranking via multi-factor scoring
 
-### Constructor
+### Tagging
 
-```typescript
-import { AutoTagger } from '@pcircle/memesh/memory/AutoTagger';
+Tags are generated inline during memory storage in UnifiedMemoryStore. The tagging logic detects:
 
-const tagger = new AutoTagger();
-```
-
-### Methods
-
-#### `generateTags(content, existingTags, context?)`
-
-Generate tags from content.
-
-**Parameters:**
-- `content: string` - Memory content to analyze
-- `existingTags: string[]` - User-provided tags
-- `context?: { projectPath?: string }` - Optional context
-
-**Returns:** `string[]` - Combined tags (existing + auto-generated, deduplicated)
-
-**Example:**
-
-```typescript
-const tags = tagger.generateTags(
-  'Use PostgreSQL for database because of JSONB support',
-  ['database'],
-  { projectPath: '/my/project' }
-);
-
-console.log(tags);
-// Output: [
-//   'database',
-//   'tech:postgresql',
-//   'domain:database',
-//   'scope:project'
-// ]
-```
-
-**Detection Coverage:**
-
-- **Tech Stack (50+ technologies)**:
-  - Languages: TypeScript, JavaScript, Python, Java, Go, Rust, etc.
-  - Frameworks: React, Vue, Next.js, Express, Django, etc.
-  - Databases: PostgreSQL, MongoDB, Redis, etc.
-  - Tools: Docker, Kubernetes, AWS, Git, etc.
-
-- **Domain Areas (8 categories)**:
-  - Frontend, Backend, Database, Auth, Security, Testing, Performance, DevOps
-
-- **Design Patterns (11 patterns)**:
-  - Singleton, Factory, Repository, Observer, Strategy, etc.
-
-- **Scope Tags**:
-  - `scope:project` - Project-specific memory
-  - `scope:global` - Global knowledge
+- **Tech Stack (50+ technologies)**: Languages, frameworks, databases, tools
+- **Domain Areas (8 categories)**: Frontend, Backend, Database, Auth, Security, Testing, Performance, DevOps
+- **Design Patterns (11 patterns)**: Singleton, Factory, Repository, Observer, Strategy, etc.
+- **Scope Tags**: `scope:project` (project-specific), `scope:global` (global knowledge)
 
 ---
 
@@ -557,7 +485,7 @@ type TimeRange = 'last-24h' | 'last-7-days' | 'last-30-days' | 'all';
 - ✅ Use hyphens for multi-word tags
 - ✅ Be specific (`react-hooks` not just `react`)
 - ✅ Include domain tags (`domain:auth`, `domain:frontend`)
-- ✅ Let AutoTagger handle tech detection
+- ✅ Let the inline auto-tagging handle tech detection
 
 **Don't:**
 - ❌ Use spaces in tags

--- a/docs/api/MEMORY_BEST_PRACTICES.md
+++ b/docs/api/MEMORY_BEST_PRACTICES.md
@@ -1,6 +1,6 @@
 # Memory System Best Practices
 
-**Complete guide for effective memory management with MeMesh memory features**
+**Complete guide for effective memory management with MeMesh Plugin memory features**
 
 This guide covers battle-tested strategies for maximizing the value of your memory system through smart tagging, importance scoring, search optimization, and auto-memory configuration.
 
@@ -155,7 +155,7 @@ Avoid storing low-value information that clutters search results.
 
 ### Understanding Search Ranking
 
-SmartMemoryQuery uses a **multi-factor scoring system**:
+MemorySearchEngine uses a **multi-factor scoring system**:
 
 \`\`\`
 Final Score = (Content Match + Tag Match + TF Score)
@@ -216,14 +216,15 @@ await memoryStore.searchByType('mistake', 'security');
 
 **Customize tag generation:**
 \`\`\`typescript
-const autoTagger = new AutoTagger();
-
-// Generate tags with custom tags preserved
-const tags = autoTagger.generateTags(
-  content,
-  ['custom-tag', 'team-specific'], // Won't be overwritten
-  { projectPath: '/frontend' }      // Context for better detection
-);
+// Tags are generated inline during memory storage in UnifiedMemoryStore.
+// Custom tags you provide are preserved and merged with auto-detected tags.
+await memoryStore.store({
+  type: 'knowledge',
+  content: content,
+  tags: ['custom-tag', 'team-specific'], // Preserved; auto-detected tags are added
+  importance: 0.7,
+  timestamp: new Date(),
+}, { projectPath: '/frontend' });
 \`\`\`
 
 ### Auto-Memory Recorder Configuration
@@ -298,11 +299,11 @@ await memoryStore.searchByType('decision', 'architecture');
 
 **Limit result sets early:**
 \`\`\`typescript
-const smartQuery = new SmartMemoryQuery();
-
-// Better: filter candidates early
-const candidates = allMemories.filter(m => m.importance >= 0.6);
-const results = smartQuery.search('query', candidates).slice(0, 20);
+// Better: use built-in filters to reduce search space early
+const results = await memoryStore.search('query', {
+  minImportance: 0.6,
+  limit: 20,
+});
 \`\`\`
 
 ---

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start Guide (2 Minutes)
 
-Get MeMesh running in under 2 minutes.
+Get MeMesh Plugin running in under 2 minutes.
 
 ## Prerequisites
 

--- a/docs/guides/SETUP.md
+++ b/docs/guides/SETUP.md
@@ -1,4 +1,4 @@
-# MeMesh Setup Guide
+# MeMesh Plugin Setup Guide
 
 ## Quick Installation (Recommended)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -99,7 +99,7 @@ src/
 ├── knowledge-graph/   # Knowledge graph (KGSearchEngine, FTS5+semantic)
 ├── embeddings/        # Vector search (sqlite-vec, ONNX)
 ├── core/              # Core logic (HookIntegration, GitCommandParser)
-├── db/                # Database management (DatabaseManager)
+├── db/                # Database management (ConnectionPool, QueryCache)
 ├── cli/               # CLI commands
 ├── config/            # Configuration management
 ├── management/        # Process management

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,11 +1,11 @@
-# MeMesh - AI Assistant Context
+# MeMesh Plugin - AI Assistant Context
 
 > Persistent memory plugin for Claude Code
 > Remembers your architecture decisions, coding patterns, and project context across sessions
 
 ## Project Overview
 
-MeMesh is a Claude Code plugin that provides persistent memory via MCP (Model Context Protocol):
+MeMesh Plugin is a Claude Code plugin that provides persistent memory via MCP (Model Context Protocol):
 - **Project Memory**: Knowledge graph remembering architecture decisions and coding patterns
 - **Cross-Session Recall**: Query past decisions, patterns, and learnings anytime
 - **Auto-Tracking**: Automatic session summaries and context capture

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memesh",
-  "description": "MeMesh — Persistent memory plugin for Claude Code. Remembers architecture decisions, coding patterns, and project context across sessions.",
+  "description": "MeMesh Plugin — Persistent memory plugin for Claude Code. Remembers architecture decisions, coding patterns, and project context across sessions.",
   "author": {
     "name": "PCIRCLE AI"
   },


### PR DESCRIPTION
## Summary
- Rename "MeMesh" → "MeMesh Plugin" across all 12 README translations and 25 documentation files
- Remove phantom tool references (`memesh-sync-remote`) and deleted module references (`AutoTagger`, `SmartMemoryQuery`) from API docs, Architecture docs, and Memory Best Practices
- Add comprehensive pre-release checklist to CLAUDE.md covering version sync, tool accuracy, naming consistency, build verification, and external sync (Obsidian)
- Update test count from 1971+ to 2202+ in CLAUDE.md

## Changes
- **37 files changed**, 338 insertions, 973 deletions (net reduction of outdated content)
- All documentation now accurately reflects v2.10.0 architecture and toolset
- No code changes — documentation only

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (2202 tests)
- [x] No remaining references to AutoTagger, SmartMemoryQuery, or memesh-sync-remote in docs
- [x] All 8 MCP tools accurately documented in API_REFERENCE.md
- [x] Version numbers consistent across package.json, plugin.json, docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)