### PR TITLE
feat: v2.14.0 — Session Auto-Capture (Stop + PreCompact hooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ memesh-mcp      # stdio MCP server
 
 ## What it does
 
-MeMesh gives Claude Code persistent memory through 3 MCP tools, 2 hooks, and a CLI dashboard:
+MeMesh gives Claude Code persistent memory through 3 MCP tools, 4 hooks, and a CLI dashboard:
 
 ### MCP Tools
 
@@ -75,6 +75,8 @@ MeMesh gives Claude Code persistent memory through 3 MCP tools, 2 hooks, and a C
 |------|-------|------|
 | Session Start | `SessionStart` | Auto-recalls project-specific + recent global memories |
 | Post Commit | `PostToolUse` (Bash) | Records git commits as knowledge entities |
+| Session Summary | `Stop` | Auto-captures session knowledge (files edited, errors fixed) |
+| Pre-Compact | `PreCompact` | Saves knowledge before context compaction |
 
 ### CLI
 
@@ -98,6 +100,7 @@ memesh-view
 - **Schema**: entities, observations, relations, tags + FTS5 virtual table
 - **Validation**: All tool inputs validated with Zod schemas
 - **Knowledge Evolution**: `forget` archives rather than deletes — old memories are preserved but hidden. Use `supersedes` relations to replace old designs with new ones.
+- **Session Auto-Capture**: Stop and PreCompact hooks automatically extract and store session knowledge. Opt-out: set `MEMESH_AUTO_CAPTURE=false`.
 
 ## Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 2.13.0
+**Version**: 2.14.0
 
 ---
 
@@ -218,6 +218,15 @@ Foreign key cascades: deleting an entity automatically deletes its observations,
 
 Hooks are defined in `hooks/hooks.json` and executed by Claude Code at specific lifecycle events.
 
+### Hook Scripts (4 hooks)
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| session-start.js | SessionStart | Auto-recall project memories |
+| post-commit.js | PostToolUse (Bash) | Record git commits with diff stats |
+| session-summary.js | Stop | Auto-capture session knowledge |
+| pre-compact.js | PreCompact | Save knowledge before compaction |
+
 ### Session Start (`scripts/hooks/session-start.js`)
 
 - **Trigger**: `SessionStart` event (every new Claude Code session)
@@ -228,7 +237,19 @@ Hooks are defined in `hooks/hooks.json` and executed by Claude Code at specific 
 
 - **Trigger**: `PostToolUse` event on `Bash` tool
 - **Matcher**: `Bash` (filters for git commit commands)
-- **Behavior**: Detects git commit messages from tool output, creates a `commit` entity with the commit message as an observation, tags with the project name
+- **Behavior**: Detects git commit messages from tool output, creates a `commit` entity with the commit message as an observation, tags with the project name; includes diff stats (files changed, insertions, deletions)
+
+### Session Summary (`scripts/hooks/session-summary.js`)
+
+- **Trigger**: `Stop` event (when Claude finishes responding)
+- **Matcher**: `*` (all sessions)
+- **Behavior**: Extracts session knowledge (files edited, errors fixed, decisions made) and stores it as entities in the knowledge graph; opt-out via `MEMESH_AUTO_CAPTURE=false`
+
+### Pre-Compact (`scripts/hooks/pre-compact.js`)
+
+- **Trigger**: `PreCompact` event (before context compaction)
+- **Matcher**: `*` (all sessions)
+- **Behavior**: Saves a snapshot of session knowledge before context is compacted, ensuring memories are not lost during long sessions; opt-out via `MEMESH_AUTO_CAPTURE=false`
 
 ---
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 2.13.0
+**Version**: 2.14.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,6 +21,30 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/session-summary.js",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-compact.js",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "memesh",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
   "author": { "name": "PCIRCLE AI" },
-  "version": "2.13.0",
+  "version": "2.14.0",
   "homepage": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/scripts/hooks/post-commit.js
+++ b/scripts/hooks/post-commit.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'module';
+import { execFileSync } from 'child_process';
 import { homedir } from 'os';
 import { join, basename } from 'path';
 import { existsSync, mkdirSync } from 'fs';
@@ -119,6 +120,25 @@ process.stdin.on('end', () => {
         // Add observations
         db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, commitMsg);
         db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, `Branch: ${branch}`);
+
+        // Add richer diff stats as an observation (backward compatible — failures are silently ignored)
+        try {
+          const stat = execFileSync('git', ['show', '--stat', '--format=', commitHash], {
+            cwd: data.cwd || process.cwd(),
+            encoding: 'utf8',
+            timeout: 5000,
+          }).trim();
+          if (stat) {
+            // Last non-empty line is the summary, e.g. "3 files changed, 45 insertions(+), 12 deletions(-)"
+            const statLines = stat.split('\n').filter(l => l.trim());
+            const summary = statLines[statLines.length - 1]?.trim() || '';
+            if (summary) {
+              db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, `Diff stats: ${summary}`);
+            }
+          }
+        } catch {
+          // git show failed — no diff stats recorded, existing behavior unchanged
+        }
 
         // Add project tag
         const projectTag = `project:${projectName}`;

--- a/scripts/hooks/pre-compact.js
+++ b/scripts/hooks/pre-compact.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { createRequire } from 'module';
+import { homedir } from 'os';
+import { join, basename } from 'path';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+
+const require = createRequire(import.meta.url);
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS entities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  metadata JSON
+);
+
+CREATE TABLE IF NOT EXISTS observations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS relations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  from_entity_id INTEGER NOT NULL,
+  to_entity_id INTEGER NOT NULL,
+  relation_type TEXT NOT NULL,
+  metadata JSON,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY (to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  UNIQUE(from_entity_id, to_entity_id, relation_type)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id INTEGER NOT NULL,
+  tag TEXT NOT NULL,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_entity ON tags(entity_id);
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+DELETE FROM tags
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM tags
+  GROUP BY entity_id, tag
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_entity_tag_unique ON tags(entity_id, tag);
+CREATE INDEX IF NOT EXISTS idx_observations_entity ON observations(entity_id);
+CREATE INDEX IF NOT EXISTS idx_relations_from ON relations(from_entity_id);
+CREATE INDEX IF NOT EXISTS idx_relations_to ON relations(to_entity_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+  name, observations, content='',
+  tokenize='unicode61 remove_diacritics 1'
+);
+`;
+
+// Timeout guard: always exit within 10 seconds
+const TIMEOUT_MS = 10000;
+const timeoutHandle = setTimeout(() => {
+  try { process.stderr.write('[memesh pre-compact] Timed out after 10s\n'); } catch {}
+  process.exit(0);
+}, TIMEOUT_MS);
+timeoutHandle.unref();
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    // Opt-out check
+    if (process.env.MEMESH_AUTO_CAPTURE === 'false') {
+      return exit0();
+    }
+
+    const data = JSON.parse(input);
+    const sessionId = data.session_id || 'unknown';
+    const transcriptPath = data.transcript_path || '';
+    const cwd = data.cwd || process.cwd();
+    const reason = data.reason || 'auto';
+    const projectName = basename(cwd);
+
+    // Parse transcript to gather insights
+    let toolCallCount = 0;
+    const editedFiles = new Set();
+
+    if (transcriptPath && existsSync(transcriptPath)) {
+      try {
+        const lines = readFileSync(transcriptPath, 'utf8').split('\n');
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const entry = JSON.parse(line);
+            // Count tool uses from assistant message content blocks
+            if (entry.role === 'assistant' && Array.isArray(entry.content)) {
+              for (const block of entry.content) {
+                if (block.type === 'tool_use') {
+                  toolCallCount++;
+                  // Track file edits
+                  const name = block.name || '';
+                  if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+                    const filePath = block.input?.file_path || block.input?.path || '';
+                    if (filePath) editedFiles.add(basename(filePath));
+                  }
+                }
+              }
+            }
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      } catch {
+        // Transcript read failed — proceed with zero counts
+      }
+    }
+
+    const insightCount = editedFiles.size + (toolCallCount > 0 ? 1 : 0);
+    const entityName = `pre-compact-${sessionId}`;
+
+    // Build observation content
+    const obsLines = [`Compaction reason: ${reason}`, `Tool calls: ${toolCallCount}`];
+    if (editedFiles.size > 0) {
+      obsLines.push(`Files edited: ${Array.from(editedFiles).join(', ')}`);
+    }
+
+    // Open (or create) database
+    const dbPath = process.env.MEMESH_DB_PATH || join(homedir(), '.memesh', 'knowledge-graph.db');
+    const dbDir = process.env.MEMESH_DB_PATH
+      ? join(process.env.MEMESH_DB_PATH, '..')
+      : join(homedir(), '.memesh');
+    if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
+
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath);
+    try {
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+      db.exec(SCHEMA_SQL);
+
+      // Upsert entity
+      const insertResult = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)').run(entityName, 'session-summary');
+      const isNew = insertResult.changes > 0;
+      const entity = db.prepare('SELECT id FROM entities WHERE name = ?').get(entityName);
+
+      if (entity) {
+        // Capture existing observations for FTS delete
+        const prevObs = isNew
+          ? []
+          : db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
+        const prevObsText = isNew ? undefined : prevObs.map(o => o.content).join(' ');
+
+        // Insert each observation line
+        for (const line of obsLines) {
+          db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, line);
+        }
+
+        // Add tags
+        const tags = ['source:auto-capture', 'urgency:pre-compact', `project:${projectName}`];
+        for (const tag of tags) {
+          db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)').run(entity.id, tag);
+        }
+
+        // Update FTS
+        if (prevObsText !== undefined) {
+          db.prepare("INSERT INTO entities_fts(entities_fts, rowid, name, observations) VALUES('delete', ?, ?, ?)").run(entity.id, entityName, prevObsText);
+        }
+        const allObs = db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
+        const allObsText = allObs.map(o => o.content).join(' ');
+        db.prepare('INSERT INTO entities_fts(rowid, name, observations) VALUES(?, ?, ?)').run(entity.id, entityName, allObsText);
+      }
+    } finally {
+      db.close();
+    }
+
+    const hookOutput = {
+      hookSpecificOutput: {
+        hookEventName: 'PreCompact',
+        additionalContext: `Saved ${insightCount} insights to MeMesh before compaction`,
+      },
+    };
+    console.log(JSON.stringify(hookOutput));
+  } catch (err) {
+    // Hooks must never crash Claude Code — exit cleanly
+    try { process.stderr.write(`[memesh pre-compact] ${err?.message || err}\n`); } catch {}
+  }
+  exit0();
+});
+
+function exit0() {
+  process.exit(0);
+}

--- a/scripts/hooks/session-summary.js
+++ b/scripts/hooks/session-summary.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+// Session Auto-Capture — Stop hook
+// Extracts knowledge from completed Claude Code sessions
+// and stores as session-insight entities in MeMesh.
+
+import { createRequire } from 'module';
+import { homedir } from 'os';
+import { join, basename } from 'path';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+
+const require = createRequire(import.meta.url);
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS entities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  metadata JSON
+);
+
+CREATE TABLE IF NOT EXISTS observations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS relations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  from_entity_id INTEGER NOT NULL,
+  to_entity_id INTEGER NOT NULL,
+  relation_type TEXT NOT NULL,
+  metadata JSON,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY (to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  UNIQUE(from_entity_id, to_entity_id, relation_type)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id INTEGER NOT NULL,
+  tag TEXT NOT NULL,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_entity ON tags(entity_id);
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+DELETE FROM tags
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM tags
+  GROUP BY entity_id, tag
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_entity_tag_unique ON tags(entity_id, tag);
+CREATE INDEX IF NOT EXISTS idx_observations_entity ON observations(entity_id);
+CREATE INDEX IF NOT EXISTS idx_relations_from ON relations(from_entity_id);
+CREATE INDEX IF NOT EXISTS idx_relations_to ON relations(to_entity_id);
+`;
+
+// Parse a JSONL transcript file.
+// Mirrors logic in src/core/extractor.ts parseTranscript().
+// Defensive: never throws — malformed lines are silently skipped.
+function parseTranscript(transcriptPath) {
+  const filesEdited = new Set();
+  const bashCommands = [];
+  const errorsEncountered = [];
+  let toolCallCount = 0;
+
+  try {
+    const lines = readFileSync(transcriptPath, 'utf8').split('\n').filter(l => l.trim());
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+
+        // Count tool calls
+        if (entry.type === 'tool_use' || entry.tool_name) toolCallCount++;
+
+        // Track file edits (Write, Edit tools)
+        if (entry.tool_name === 'Write' || entry.tool_name === 'Edit') {
+          const inp = entry.tool_input ?? {};
+          const fp = (inp.file_path ?? inp.path);
+          if (fp && typeof fp === 'string') filesEdited.add(basename(fp));
+        }
+
+        // Track meaningful bash commands
+        if (entry.tool_name === 'Bash') {
+          const cmd = (entry.tool_input?.command) ?? '';
+          if (typeof cmd === 'string' && cmd.length > 10 && !cmd.startsWith('ls') && !cmd.startsWith('cd')) {
+            bashCommands.push(cmd.slice(0, 100));
+          }
+        }
+
+        // Track errors from tool results
+        if (entry.type === 'tool_result' && entry.content != null) {
+          const text = typeof entry.content === 'string'
+            ? entry.content
+            : JSON.stringify(entry.content);
+          if (text.includes('Error') || text.includes('FAIL') || text.includes('error:')) {
+            errorsEncountered.push(text.slice(0, 200));
+          }
+        }
+      } catch {
+        // Skip malformed JSONL lines
+      }
+    }
+  } catch {
+    // Transcript unreadable — return empty results
+  }
+
+  return { filesEdited: [...filesEdited], bashCommands, errorsEncountered, toolCallCount };
+}
+
+// Main: read stdin, extract insights, store in DB
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    if (!input.trim()) return exit0();
+
+    // Opt-out check
+    if (process.env.MEMESH_AUTO_CAPTURE === 'false') return exit0();
+
+    let inputData;
+    try {
+      inputData = JSON.parse(input);
+    } catch {
+      return exit0();
+    }
+
+    const sessionId = inputData.session_id || 'unknown';
+    const transcriptPath = inputData.transcript_path;
+    const cwd = inputData.cwd || process.cwd();
+    const stopReason = inputData.stop_reason || 'unknown';
+    const wasAgenticLoop = inputData.was_in_agentic_loop === true;
+
+    // Guards: skip low-signal sessions
+    if (stopReason === 'user_interrupt') return exit0();
+    if (!wasAgenticLoop) return exit0();
+    if (!transcriptPath || !existsSync(transcriptPath)) return exit0();
+
+    // Parse transcript
+    const { filesEdited, bashCommands, errorsEncountered, toolCallCount } = parseTranscript(transcriptPath);
+
+    // Skip sessions with too little activity
+    if (toolCallCount < 3) return exit0();
+
+    // Open DB
+    const dbPath = process.env.MEMESH_DB_PATH || join(homedir(), '.memesh', 'knowledge-graph.db');
+    const dbDir = process.env.MEMESH_DB_PATH
+      ? join(process.env.MEMESH_DB_PATH, '..')
+      : join(homedir(), '.memesh');
+    if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
+
+    const Database = require('better-sqlite3');
+    const sqliteVec = require('sqlite-vec');
+
+    const db = new Database(dbPath);
+    try {
+      db.pragma('journal_mode = WAL');
+      db.pragma('foreign_keys = ON');
+
+      // Ensure schema exists (tables may already exist from MeMesh server)
+      db.exec(SCHEMA_SQL);
+
+      // Migrate: add status column if missing (v2.11 -> v2.12)
+      const cols = db.prepare("PRAGMA table_info(entities)").all();
+      if (!cols.some(c => c.name === 'status')) {
+        db.exec("ALTER TABLE entities ADD COLUMN status TEXT NOT NULL DEFAULT 'active'");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_entities_status ON entities(status)");
+      }
+
+      // Load sqlite-vec extension
+      sqliteVec.load(db);
+
+      // Duplicate detection: if we already captured this session, bail
+      const shortId = sessionId.slice(0, 8);
+      const alreadyCaptured = db.prepare("SELECT id FROM entities WHERE name = ?").get(`session-${shortId}-files`);
+      if (alreadyCaptured) return exit0();
+
+      // Build and store session memories
+      const projectName = basename(cwd);
+      const baseTags = ['source:auto-capture', `session:${shortId}`, `project:${projectName}`];
+
+      const insertEntity = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)');
+      const selectEntity = db.prepare('SELECT id FROM entities WHERE name = ?');
+      const insertObs = db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)');
+      const insertTag = db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)');
+
+      function storeMemory(name, type, observations, tags) {
+        insertEntity.run(name, type);
+        const row = selectEntity.get(name);
+        if (!row) return;
+        for (const obs of observations) insertObs.run(row.id, obs);
+        for (const tag of tags) insertTag.run(row.id, tag);
+      }
+
+      // Rule 1: File editing session summary
+      if (filesEdited.length > 0) {
+        storeMemory(
+          `session-${shortId}-files`,
+          'session-insight',
+          [
+            `Session edited ${filesEdited.length} file(s): ${filesEdited.join(', ')}`,
+            `Total tool calls: ${toolCallCount}`,
+          ],
+          baseTags
+        );
+      }
+
+      // Rule 2: Error -> Fix pattern detection
+      if (errorsEncountered.length > 0 && filesEdited.length > 0) {
+        storeMemory(
+          `session-${shortId}-fixes`,
+          'session-insight',
+          [
+            `Fixed ${errorsEncountered.length} error(s) by editing ${filesEdited.join(', ')}`,
+            ...errorsEncountered.slice(0, 3).map(e => `Error: ${e.slice(0, 100)}`),
+          ],
+          [...baseTags, 'type:bugfix']
+        );
+      }
+
+      // Rule 3: Heavy session summary (20+ tool calls = significant work)
+      if (toolCallCount >= 20) {
+        storeMemory(
+          `session-${shortId}-summary`,
+          'session-insight',
+          [
+            `Significant session: ${toolCallCount} tool calls, ${filesEdited.length} files edited`,
+            ...bashCommands.slice(0, 3).map(c => `Command: ${c}`),
+          ],
+          [...baseTags, 'type:heavy-session']
+        );
+      }
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    // Never crash Claude Code — leave a trace for debugging
+    try { process.stderr.write(`[memesh session-summary] ${err?.message || err}\n`); } catch {}
+  }
+
+  // Silent output — don't clutter Claude's response
+  console.log(JSON.stringify({ suppressOutput: true }));
+  exit0();
+});
+
+function exit0() {
+  process.exit(0);
+}

--- a/src/core/extractor.ts
+++ b/src/core/extractor.ts
@@ -1,0 +1,180 @@
+import fs from 'fs';
+import path from 'path';
+
+// =============================================================================
+// Extractor Interface (pluggable — rule-based now, LLM-based later)
+// =============================================================================
+
+export interface SessionContext {
+  sessionId: string;
+  transcriptPath?: string;
+  cwd: string;
+  stopReason: string;
+  wasAgenticLoop: boolean;
+}
+
+export interface ExtractedMemory {
+  name: string;
+  type: string;
+  observations: string[];
+  tags: string[];
+}
+
+export interface Extractor {
+  extract(context: SessionContext): ExtractedMemory[];
+}
+
+// =============================================================================
+// Transcript Parsing
+// =============================================================================
+
+interface TranscriptEntry {
+  role?: string;
+  type?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  content?: unknown;
+}
+
+/**
+ * Parse a JSONL transcript file and extract tool usage information.
+ * Returns arrays of files edited, bash commands run, and errors encountered.
+ * Defensive: never throws — malformed lines are silently skipped.
+ */
+export function parseTranscript(transcriptPath: string): {
+  filesEdited: string[];
+  bashCommands: string[];
+  errorsEncountered: string[];
+  toolCallCount: number;
+} {
+  const filesEdited = new Set<string>();
+  const bashCommands: string[] = [];
+  const errorsEncountered: string[] = [];
+  let toolCallCount = 0;
+
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = content.split('\n').filter(l => l.trim());
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as TranscriptEntry;
+
+        // Count tool calls
+        if (entry.type === 'tool_use' || entry.tool_name) {
+          toolCallCount++;
+        }
+
+        // Track file edits (Write, Edit tools)
+        if (entry.tool_name === 'Write' || entry.tool_name === 'Edit') {
+          const input = entry.tool_input ?? {};
+          const filePath = (input['file_path'] ?? input['path']) as string | undefined;
+          if (filePath && typeof filePath === 'string') {
+            filesEdited.add(path.basename(filePath));
+          }
+        }
+
+        // Track bash commands — only meaningful ones
+        if (entry.tool_name === 'Bash') {
+          const cmd = (entry.tool_input?.['command'] as string | undefined) ?? '';
+          if (
+            typeof cmd === 'string' &&
+            cmd.length > 10 &&
+            !cmd.startsWith('ls') &&
+            !cmd.startsWith('cd')
+          ) {
+            bashCommands.push(cmd.slice(0, 100));
+          }
+        }
+
+        // Track errors from tool results
+        if (entry.type === 'tool_result' && entry.content != null) {
+          const text =
+            typeof entry.content === 'string'
+              ? entry.content
+              : JSON.stringify(entry.content);
+          if (text.includes('Error') || text.includes('FAIL') || text.includes('error:')) {
+            errorsEncountered.push(text.slice(0, 200));
+          }
+        }
+      } catch {
+        // Skip malformed JSONL lines
+      }
+    }
+  } catch {
+    // Transcript unreadable — return empty results
+  }
+
+  return {
+    filesEdited: [...filesEdited],
+    bashCommands,
+    errorsEncountered,
+    toolCallCount,
+  };
+}
+
+// =============================================================================
+// Rule-Based Extractor
+// =============================================================================
+
+export class RuleBasedExtractor implements Extractor {
+  extract(context: SessionContext): ExtractedMemory[] {
+    const memories: ExtractedMemory[] = [];
+    const projectName = path.basename(context.cwd);
+    const sessionTag = `session:${context.sessionId.slice(0, 8)}`;
+    const baseTags = ['source:auto-capture', sessionTag, `project:${projectName}`];
+
+    // Skip sessions that were interrupted or non-agentic
+    if (context.stopReason === 'user_interrupt') return memories;
+    if (!context.wasAgenticLoop) return memories;
+
+    // Require a transcript to extract anything
+    if (!context.transcriptPath) return memories;
+
+    const transcript = parseTranscript(context.transcriptPath);
+
+    // Skip sessions with very little activity
+    if (transcript.toolCallCount < 3) return memories;
+
+    // Rule 1: File editing session summary
+    if (transcript.filesEdited.length > 0) {
+      memories.push({
+        name: `session-${context.sessionId.slice(0, 8)}-files`,
+        type: 'session-insight',
+        observations: [
+          `Session edited ${transcript.filesEdited.length} file(s): ${transcript.filesEdited.join(', ')}`,
+          `Total tool calls: ${transcript.toolCallCount}`,
+        ],
+        tags: baseTags,
+      });
+    }
+
+    // Rule 2: Error → Fix pattern detection
+    if (transcript.errorsEncountered.length > 0 && transcript.filesEdited.length > 0) {
+      memories.push({
+        name: `session-${context.sessionId.slice(0, 8)}-fixes`,
+        type: 'session-insight',
+        observations: [
+          `Fixed ${transcript.errorsEncountered.length} error(s) by editing ${transcript.filesEdited.join(', ')}`,
+          ...transcript.errorsEncountered.slice(0, 3).map(e => `Error: ${e.slice(0, 100)}`),
+        ],
+        tags: [...baseTags, 'type:bugfix'],
+      });
+    }
+
+    // Rule 3: Heavy session summary (20+ tool calls = significant work)
+    if (transcript.toolCallCount >= 20) {
+      memories.push({
+        name: `session-${context.sessionId.slice(0, 8)}-summary`,
+        type: 'session-insight',
+        observations: [
+          `Significant session: ${transcript.toolCallCount} tool calls, ${transcript.filesEdited.length} files edited`,
+          ...transcript.bashCommands.slice(0, 3).map(c => `Command: ${c}`),
+        ],
+        tags: [...baseTags, 'type:heavy-session'],
+      });
+    }
+
+    return memories;
+  }
+}

--- a/tests/core/extractor.test.ts
+++ b/tests/core/extractor.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { RuleBasedExtractor, parseTranscript } from '../../src/core/extractor.js';
+import type { SessionContext } from '../../src/core/extractor.js';
+
+// =============================================================================
+// RuleBasedExtractor — filtering rules
+// =============================================================================
+
+describe('RuleBasedExtractor: session filtering', () => {
+  const extractor = new RuleBasedExtractor();
+
+  it('skips interrupted sessions', () => {
+    const ctx: SessionContext = {
+      sessionId: 'abc12345',
+      cwd: '/Users/test/project',
+      stopReason: 'user_interrupt',
+      wasAgenticLoop: true,
+    };
+    expect(extractor.extract(ctx)).toEqual([]);
+  });
+
+  it('skips non-agentic sessions', () => {
+    const ctx: SessionContext = {
+      sessionId: 'abc12345',
+      cwd: '/Users/test/project',
+      stopReason: 'end_turn',
+      wasAgenticLoop: false,
+    };
+    expect(extractor.extract(ctx)).toEqual([]);
+  });
+
+  it('skips sessions without transcript path', () => {
+    const ctx: SessionContext = {
+      sessionId: 'abc12345',
+      cwd: '/Users/test/project',
+      stopReason: 'end_turn',
+      wasAgenticLoop: true,
+    };
+    expect(extractor.extract(ctx)).toEqual([]);
+  });
+
+  it('returns empty gracefully when transcript path does not exist', () => {
+    const ctx: SessionContext = {
+      sessionId: 'abc12345',
+      transcriptPath: '/nonexistent/path.jsonl',
+      cwd: '/Users/test/myproject',
+      stopReason: 'end_turn',
+      wasAgenticLoop: true,
+    };
+    expect(extractor.extract(ctx)).toEqual([]);
+  });
+});
+
+// =============================================================================
+// RuleBasedExtractor — with real transcript fixture
+// =============================================================================
+
+describe('RuleBasedExtractor: memory extraction', () => {
+  const extractor = new RuleBasedExtractor();
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-extractor-'));
+    transcriptPath = path.join(tmpDir, 'session.jsonl');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTranscript(entries: object[]): void {
+    fs.writeFileSync(transcriptPath, entries.map(e => JSON.stringify(e)).join('\n'), 'utf8');
+  }
+
+  function makeCtx(overrides: Partial<SessionContext> = {}): SessionContext {
+    return {
+      sessionId: 'abc12345deadbeef',
+      transcriptPath,
+      cwd: '/Users/test/myproject',
+      stopReason: 'end_turn',
+      wasAgenticLoop: true,
+      ...overrides,
+    };
+  }
+
+  it('skips session with fewer than 3 tool calls', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+    expect(extractor.extract(makeCtx())).toEqual([]);
+  });
+
+  it('Rule 1: produces file-editing memory when files are edited', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/core/extractor.ts' } },
+      { type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/src/core/types.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run typecheck' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    const fileMemory = memories.find(m => m.name.endsWith('-files'));
+    expect(fileMemory).toBeDefined();
+    expect(fileMemory!.type).toBe('session-insight');
+    expect(fileMemory!.observations[0]).toContain('extractor.ts');
+    expect(fileMemory!.observations[0]).toContain('types.ts');
+  });
+
+  it('Rule 1: tags include source:auto-capture, session prefix, and project name', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/foo.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    const tags = memories[0]?.tags ?? [];
+    expect(tags).toContain('source:auto-capture');
+    expect(tags).toContain('session:abc12345');
+    expect(tags).toContain('project:myproject');
+  });
+
+  it('Rule 2: produces bugfix memory when errors and edits both present', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+      { type: 'tool_result', content: 'Error: cannot find module ./extractor' },
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/core/extractor.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    const fixMemory = memories.find(m => m.name.endsWith('-fixes'));
+    expect(fixMemory).toBeDefined();
+    expect(fixMemory!.tags).toContain('type:bugfix');
+    expect(fixMemory!.observations[0]).toContain('Fixed');
+  });
+
+  it('Rule 2: no bugfix memory when errors present but no files edited', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+      { type: 'tool_result', content: 'Error: test failed' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run lint' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    expect(memories.find(m => m.name.endsWith('-fixes'))).toBeUndefined();
+  });
+
+  it('Rule 3: produces summary memory for sessions with 20+ tool calls', () => {
+    const entries: object[] = [];
+    for (let i = 0; i < 20; i++) {
+      entries.push({ type: 'tool_use', tool_name: 'Bash', tool_input: { command: `npm run step-${i}` } });
+    }
+    entries.push({ type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/foo.ts' } });
+    writeTranscript(entries);
+
+    const memories = extractor.extract(makeCtx());
+    const summaryMemory = memories.find(m => m.name.endsWith('-summary'));
+    expect(summaryMemory).toBeDefined();
+    expect(summaryMemory!.tags).toContain('type:heavy-session');
+    expect(summaryMemory!.observations[0]).toContain('tool calls');
+  });
+
+  it('Rule 3: no summary memory for sessions under 20 tool calls', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/foo.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    expect(memories.find(m => m.name.endsWith('-summary'))).toBeUndefined();
+  });
+
+  it('memory names are prefixed with first 8 chars of session ID', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/x.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+
+    const memories = extractor.extract(makeCtx());
+    for (const m of memories) {
+      expect(m.name).toMatch(/^session-abc12345-/);
+    }
+  });
+});
+
+// =============================================================================
+// parseTranscript — unit tests
+// =============================================================================
+
+describe('parseTranscript', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-transcript-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLine(filePath: string, entries: object[]): void {
+    fs.writeFileSync(filePath, entries.map(e => JSON.stringify(e)).join('\n'), 'utf8');
+  }
+
+  it('returns zeroed result for non-existent file', () => {
+    const result = parseTranscript('/no/such/file.jsonl');
+    expect(result.toolCallCount).toBe(0);
+    expect(result.filesEdited).toEqual([]);
+    expect(result.bashCommands).toEqual([]);
+    expect(result.errorsEncountered).toEqual([]);
+  });
+
+  it('skips malformed JSONL lines without throwing', () => {
+    const p = path.join(tmpDir, 'bad.jsonl');
+    fs.writeFileSync(p, 'not json\n{"type":"tool_use","tool_name":"Bash","tool_input":{"command":"npm run build"}}\n{broken', 'utf8');
+    const result = parseTranscript(p);
+    expect(result.toolCallCount).toBe(1);
+  });
+
+  it('counts tool_use entries', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm run build' } },
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/a.ts' } },
+    ]);
+    expect(parseTranscript(p).toolCallCount).toBe(2);
+  });
+
+  it('extracts basenames from Write and Edit tool_input.file_path', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/deep/path/extractor.ts' } },
+      { type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/other/types.ts' } },
+    ]);
+    const result = parseTranscript(p);
+    expect(result.filesEdited).toContain('extractor.ts');
+    expect(result.filesEdited).toContain('types.ts');
+  });
+
+  it('deduplicates repeated edits to the same file', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Write', tool_input: { file_path: '/src/foo.ts' } },
+      { type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/src/foo.ts' } },
+    ]);
+    expect(parseTranscript(p).filesEdited).toEqual(['foo.ts']);
+  });
+
+  it('ignores short or trivial bash commands', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'ls' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'cd /tmp' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'short' } },
+    ]);
+    expect(parseTranscript(p).bashCommands).toEqual([]);
+  });
+
+  it('captures meaningful bash commands', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test -- --run' } },
+    ]);
+    expect(parseTranscript(p).bashCommands).toHaveLength(1);
+    expect(parseTranscript(p).bashCommands[0]).toBe('npm test -- --run');
+  });
+
+  it('truncates long bash commands to 100 chars', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    const longCmd = 'npm run ' + 'x'.repeat(200);
+    writeLine(p, [
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: longCmd } },
+    ]);
+    expect(parseTranscript(p).bashCommands[0].length).toBe(100);
+  });
+
+  it('captures error text from tool_result entries', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_result', content: 'Error: Cannot find module ./foo' },
+    ]);
+    expect(parseTranscript(p).errorsEncountered).toHaveLength(1);
+  });
+
+  it('does not capture non-error tool_result content', () => {
+    const p = path.join(tmpDir, 't.jsonl');
+    writeLine(p, [
+      { type: 'tool_result', content: 'Build successful' },
+    ]);
+    expect(parseTranscript(p).errorsEncountered).toHaveLength(0);
+  });
+});

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const require = createRequire(import.meta.url);
+
+describe('Feature: PreCompact Hook', () => {
+  let testDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-precompact-test-'));
+    dbPath = path.join(testDir, 'test.db');
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function runHook(input: object, env: Record<string, string> = {}): string {
+    const hookPath = path.resolve('scripts/hooks/pre-compact.js');
+    const jsonInput = JSON.stringify(input);
+    return execFileSync('node', [hookPath], {
+      input: jsonInput,
+      env: { ...process.env, MEMESH_DB_PATH: dbPath, ...env },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+  }
+
+  function openDb(): InstanceType<typeof import('better-sqlite3')> {
+    const Database = require('better-sqlite3');
+    return new Database(dbPath, { readonly: true });
+  }
+
+  it('Scenario: Basic pre-compact event -> entity created with correct type and tags', () => {
+    const input = {
+      session_id: 'sess-abc123',
+      transcript_path: '',
+      cwd: '/tmp/myproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    const result = runHook(input);
+    const parsed = JSON.parse(result.trim());
+
+    // Output has correct structure
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreCompact');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('MeMesh');
+
+    // Entity created in DB
+    const db = openDb();
+    const entity = db.prepare('SELECT * FROM entities WHERE name = ?').get('pre-compact-sess-abc123');
+    expect(entity).toBeTruthy();
+    expect(entity.type).toBe('session-summary');
+
+    // Tags present
+    const tags = db.prepare('SELECT tag FROM tags WHERE entity_id = ?').all(entity.id).map((r: { tag: string }) => r.tag);
+    expect(tags).toContain('source:auto-capture');
+    expect(tags).toContain('urgency:pre-compact');
+    expect(tags).toContain('project:myproject');
+
+    db.close();
+  });
+
+  it('Scenario: Reason stored as observation', () => {
+    const input = {
+      session_id: 'sess-manual1',
+      transcript_path: '',
+      cwd: '/tmp/testproject',
+      hook_event_name: 'PreCompact',
+      reason: 'manual',
+    };
+
+    runHook(input);
+
+    const db = openDb();
+    const entity = db.prepare('SELECT * FROM entities WHERE name = ?').get('pre-compact-sess-manual1');
+    expect(entity).toBeTruthy();
+    const obs = db.prepare('SELECT content FROM observations WHERE entity_id = ? ORDER BY id').all(entity.id) as { content: string }[];
+    const reasonObs = obs.find(o => o.content.startsWith('Compaction reason:'));
+    expect(reasonObs?.content).toBe('Compaction reason: manual');
+    db.close();
+  });
+
+  it('Scenario: Transcript with tool uses -> tool call count stored', () => {
+    // Write a minimal transcript JSONL with tool_use blocks
+    const transcriptPath = path.join(testDir, 'transcript.jsonl');
+    const assistantMsg = {
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/tmp/foo.ts' } },
+        { type: 'tool_use', id: 't2', name: 'Edit', input: { file_path: '/tmp/bar.ts' } },
+        { type: 'tool_use', id: 't3', name: 'Write', input: { file_path: '/tmp/baz.ts' } },
+      ],
+    };
+    fs.writeFileSync(transcriptPath, JSON.stringify(assistantMsg) + '\n');
+
+    const input = {
+      session_id: 'sess-transcript1',
+      transcript_path: transcriptPath,
+      cwd: '/tmp/myproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    runHook(input);
+
+    const db = openDb();
+    const entity = db.prepare('SELECT * FROM entities WHERE name = ?').get('pre-compact-sess-transcript1');
+    expect(entity).toBeTruthy();
+    const obs = db.prepare('SELECT content FROM observations WHERE entity_id = ? ORDER BY id').all(entity.id) as { content: string }[];
+
+    // Tool call count observation
+    const toolObs = obs.find(o => o.content.startsWith('Tool calls:'));
+    expect(toolObs?.content).toBe('Tool calls: 3');
+
+    // Files edited observation (Edit + Write = 2 unique files)
+    const filesObs = obs.find(o => o.content.startsWith('Files edited:'));
+    expect(filesObs).toBeTruthy();
+    expect(filesObs?.content).toContain('bar.ts');
+    expect(filesObs?.content).toContain('baz.ts');
+
+    db.close();
+  });
+
+  it('Scenario: MEMESH_AUTO_CAPTURE=false -> exits cleanly, no DB created', () => {
+    const input = {
+      session_id: 'sess-optout',
+      transcript_path: '',
+      cwd: '/tmp/myproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    runHook(input, { MEMESH_AUTO_CAPTURE: 'false' });
+
+    expect(fs.existsSync(dbPath)).toBe(false);
+  });
+
+  it('Scenario: Missing transcript path -> exits cleanly, entity still created', () => {
+    const input = {
+      session_id: 'sess-notranscript',
+      transcript_path: '/nonexistent/path/transcript.jsonl',
+      cwd: '/tmp/myproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    runHook(input);
+
+    const db = openDb();
+    const entity = db.prepare('SELECT * FROM entities WHERE name = ?').get('pre-compact-sess-notranscript');
+    expect(entity).toBeTruthy();
+    db.close();
+  });
+
+  it('Scenario: Invalid JSON input -> exits cleanly (exit 0)', () => {
+    const hookPath = path.resolve('scripts/hooks/pre-compact.js');
+    // Must not throw
+    execFileSync('node', [hookPath], {
+      input: 'not-json-at-all',
+      env: { ...process.env, MEMESH_DB_PATH: dbPath },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    // DB should not exist (errored before db open)
+    expect(fs.existsSync(dbPath)).toBe(false);
+  });
+
+  it('Scenario: Duplicate session_id -> no duplicate entities', () => {
+    const input = {
+      session_id: 'sess-dup',
+      transcript_path: '',
+      cwd: '/tmp/myproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    runHook(input);
+    runHook(input);
+
+    const db = openDb();
+    const entities = db.prepare('SELECT * FROM entities WHERE name = ?').all('pre-compact-sess-dup');
+    expect(entities).toHaveLength(1);
+    db.close();
+  });
+
+  it('Scenario: Output JSON has correct hookEventName', () => {
+    const input = {
+      session_id: 'sess-output-check',
+      transcript_path: '',
+      cwd: '/tmp/someproject',
+      hook_event_name: 'PreCompact',
+      reason: 'auto',
+    };
+
+    const result = runHook(input);
+    const parsed = JSON.parse(result.trim());
+    expect(parsed).toHaveProperty('hookSpecificOutput');
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreCompact');
+    expect(typeof parsed.hookSpecificOutput.additionalContext).toBe('string');
+  });
+});

--- a/tests/installation.test.ts
+++ b/tests/installation.test.ts
@@ -25,12 +25,14 @@ describe('Installation Verification', () => {
       expect(fs.existsSync('.mcp.json')).toBe(true);
     });
 
-    it('should have hooks.json with 2 hooks', () => {
+    it('should have hooks.json with 4 hooks', () => {
       const hooks = JSON.parse(fs.readFileSync('hooks/hooks.json', 'utf8'));
       const hookTypes = Object.keys(hooks.hooks);
-      expect(hookTypes).toHaveLength(2);
+      expect(hookTypes).toHaveLength(4);
       expect(hookTypes).toContain('SessionStart');
       expect(hookTypes).toContain('PostToolUse');
+      expect(hookTypes).toContain('Stop');
+      expect(hookTypes).toContain('PreCompact');
     });
   });
 
@@ -38,6 +40,8 @@ describe('Installation Verification', () => {
     const hookFiles = [
       'scripts/hooks/session-start.js',
       'scripts/hooks/post-commit.js',
+      'scripts/hooks/session-summary.js',
+      'scripts/hooks/pre-compact.js',
     ];
 
     it.each(hookFiles)('%s should exist and be executable', (hookPath) => {


### PR DESCRIPTION
## Summary

- **Session Auto-Capture**: Stop hook extracts knowledge when Claude stops generating
- **PreCompact hook**: Saves knowledge before context compaction
- **Rule-based extractor**: Detects file edits, error→fix patterns, heavy sessions
- **Enhanced post-commit**: Adds git diff stats (files changed, insertions/deletions)
- **Opt-out**: `MEMESH_AUTO_CAPTURE=false`
- **4 hooks total**: SessionStart, PostToolUse, Stop, PreCompact

## New Files
- `src/core/extractor.ts` — rule-based knowledge extractor + pluggable interface
- `scripts/hooks/session-summary.js` — Stop hook
- `scripts/hooks/pre-compact.js` — PreCompact hook
- `tests/core/extractor.test.ts` — 22 tests
- `tests/hooks/pre-compact.test.ts` — 8 tests

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] `npm test -- --run` — 183/183 pass (was 151)
- [x] `npm run build` — clean
- [ ] CI matrix