### PR TITLE
feat: v2.15.0 — Smart Recall (scoring, LLM expansion, conflict detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ MeMesh gives Claude Code persistent memory through 3 MCP tools, 4 hooks, and a C
 | Tool | Description |
 |------|-------------|
 | `remember` | Store knowledge — entities with observations, relations, and tags |
-| `recall` | Search stored knowledge via FTS5 full-text search with optional tag filtering |
+| `recall` | Search stored knowledge via FTS5 full-text search with scoring, Smart Recall (LLM query expansion), and conflict detection |
 | `forget` | Archive knowledge (soft-delete) or remove specific observations |
 
 ### Transports
@@ -93,7 +93,9 @@ memesh-view
 ## How it works
 
 - **Storage**: SQLite database at `~/.memesh/knowledge-graph.db`
-- **Search**: FTS5 full-text search (no vector embeddings)
+- **Search**: FTS5 full-text search with multi-factor scoring (recency, frequency, confidence, temporal validity)
+- **Smart Recall**: When an LLM is configured, queries are expanded into related terms before searching (Level 1 / Smart Mode). Results from all terms are merged and re-ranked by score.
+- **Conflict Detection**: Recall warns when any returned entities have `contradicts` relations — surfaced as warnings in CLI output and as a `conflicts` field in MCP/HTTP responses.
 - **Isolation**: Tag-based project filtering (`project:<name>`)
 - **Upserts**: Reusing an entity name appends observations, preserves the original type, and dedupes tags
 - **Dashboard**: `memesh-view` bundles D3 locally, so the generated HTML works offline

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 2.14.0
+**Version**: 2.15.0
 
 ---
 
@@ -30,7 +30,9 @@ MeMesh v2.13 separates concerns into two layers:
 **Core** (`src/core/`) — pure business logic with zero transport dependencies:
 - `types.ts` — shared TypeScript interfaces (zero external deps)
 - `operations.ts` — `remember`, `recall`, `forget` as pure functions called by all transports
-- `config.ts` — config management + capability detection (sqlite-vec availability)
+- `config.ts` — config management + capability detection (sqlite-vec availability); exports `logCapabilities()` for startup logging
+- `scoring.ts` — multi-factor scoring engine: weights search relevance, recency, frequency, confidence, temporal validity; exports `rankEntities()` used by all recall paths
+- `query-expander.ts` — LLM-powered query expansion (Level 1): expands a user query into related terms using a configured LLM (Anthropic/OpenAI/Ollama)
 - `version-check.ts` — npm registry version check for update notifications
 
 **Transports** (`src/transports/`) — thin adapters that expose core operations:
@@ -48,22 +50,24 @@ This separation means the same `remember`/`recall`/`forget` logic runs identical
 src/
 ├── core/
 │   ├── types.ts           # Shared types (zero external deps)
-│   ├── operations.ts      # remember/recall/forget pure functions
-│   ├── config.ts          # Config management + capability detection
+│   ├── operations.ts      # remember/recall/forget pure functions (scoring applied here)
+│   ├── config.ts          # Config management + capability detection + logCapabilities()
+│   ├── scoring.ts         # Multi-factor scoring engine (rankEntities)
+│   ├── query-expander.ts  # LLM query expansion (Level 1)
 │   └── version-check.ts   # npm registry version check
 ├── db.ts                  # SQLite + FTS5 + sqlite-vec + migrations
-├── knowledge-graph.ts     # Entity CRUD, relations, FTS5 search
+├── knowledge-graph.ts     # Entity CRUD, relations, FTS5 search, findConflicts
 ├── index.ts               # Package exports
 ├── cli/
 │   └── view.ts            # HTML dashboard generator
 └── transports/
     ├── mcp/
-    │   ├── handlers.ts    # MCP tool handlers (Zod + ToolResult wrapper)
-    │   └── server.ts      # MCP stdio server
+    │   ├── handlers.ts    # MCP tool handlers (Zod + ToolResult wrapper + conflict detection)
+    │   └── server.ts      # MCP stdio server (logs capabilities on startup)
     ├── http/
-    │   └── server.ts      # Express REST API server
+    │   └── server.ts      # Express REST API server (logs capabilities on startup, conflict detection)
     └── cli/
-        └── cli.ts         # Commander CLI
+        └── cli.ts         # Commander CLI (conflict warnings in recall output)
 ```
 
 ---
@@ -76,7 +80,11 @@ src/
 
 **operations.ts** — Pure functions implementing `remember`, `recall`, and `forget`. All three transports delegate here — no transport-specific logic leaks into business logic.
 
-**config.ts** — Config management: reads `MEMESH_DB_PATH` and other environment variables, detects sqlite-vec availability, exposes a typed config object to transports and core functions.
+**config.ts** — Config management: reads `MEMESH_DB_PATH` and other environment variables, detects sqlite-vec availability, exposes a typed config object to transports and core functions. `logCapabilities()` logs detected search level and LLM provider to stderr on server startup (safe for MCP stdio transport).
+
+**scoring.ts** — Multi-factor scoring engine. `scoreEntity()` combines five signals: search relevance (0.35), recency via exponential decay (0.25), access frequency via log normalization (0.20), confidence (0.15), and temporal validity (0.05). `rankEntities()` sorts any entity list by score descending. Applied in all recall paths (`recall()` and `recallEnhanced()`).
+
+**query-expander.ts** — LLM-powered query expansion (Level 1). When a LLM is configured (Anthropic, OpenAI, or Ollama), `expandQuery()` generates related search terms for a user query. Results from expanded terms are merged with original-query results and re-ranked by score (original query = 1.0 relevance, expanded terms = 0.7 relevance).
 
 **version-check.ts** — Queries the npm registry for the latest `@pcircle/memesh` version and emits an update notification if the installed version is behind.
 
@@ -107,8 +115,9 @@ CRUD operations and full-text search over the entity graph.
 - `getRelations(entityName)` -- All outgoing relations for an entity
 
 **Search**:
-- `search(query?, opts?)` -- FTS5 MATCH query with optional tag filtering
+- `search(query?, opts?)` -- FTS5 MATCH query with optional tag filtering; tracks access on returned entities
 - `listRecent(limit?)` -- Most recent entities by ID
+- `findConflicts(entityNames[])` -- Returns conflict descriptions for any `contradicts` relations among the given entity names; surfaced as warnings by all three transports
 
 FTS5 is configured as a contentless virtual table (`content=''`). The `rebuildFts()` method handles explicit insert/delete operations required by contentless FTS5.
 
@@ -167,12 +176,13 @@ Tool call: remember({name, type, observations, tags, relations})
 ```
 Tool call: recall({query, tag, limit})
   -> Zod validation (RecallSchema)
-  -> KnowledgeGraph.search(query, {tag, limit})
-     -> FTS5 MATCH query against entities_fts
-     -> Apply tag filtering in SQL when specified
-     -> JOIN to entities table (contentless FTS5)
-     -> For each match: getEntity() to load full data
-  -> Return Entity[]
+  -> recallEnhanced() in core/operations
+     -> If LLM configured: expandQuery() generates related terms (Level 1)
+     -> KnowledgeGraph.search() for each term (original=1.0, expanded=0.7 relevance)
+     -> Merge results de-duped by entity name
+     -> rankEntities() applies multi-factor scoring (relevance, recency, frequency, confidence, temporal validity)
+     -> KnowledgeGraph.findConflicts() checks for contradicts relations among results
+  -> If conflicts: return {entities, conflicts}; else return Entity[]
 ```
 
 ### Delete knowledge (forget)
@@ -194,7 +204,7 @@ Tool call: forget({name})
 
 ```sql
 -- Core tables
-entities (id PK, name UNIQUE, type, created_at, metadata JSON)
+entities (id PK, name UNIQUE, type, created_at, metadata JSON, status, access_count, last_accessed_at, confidence, valid_from, valid_until)
 observations (id PK, entity_id FK, content, created_at)
 relations (id PK, from_entity_id FK, to_entity_id FK, relation_type, metadata JSON, created_at, UNIQUE constraint)
 tags (id PK, entity_id FK, tag)

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 2.14.0
+**Version**: 2.15.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---
@@ -83,7 +83,7 @@ If a relation target does not exist, the entity is still stored and `relationErr
 
 ### recall
 
-Search and retrieve stored knowledge. Uses FTS5 full-text search with optional tag filtering. Call with no query to list recent memories.
+Search and retrieve stored knowledge. Uses FTS5 full-text search with optional tag filtering and multi-factor scoring. When an LLM is configured (Smart Mode, Level 1), the query is expanded into related terms before searching. Results are ranked by a weighted combination of search relevance, recency, access frequency, confidence, and temporal validity. Call with no query to list recent memories.
 
 **Input Schema**:
 
@@ -96,7 +96,7 @@ Search and retrieve stored knowledge. Uses FTS5 full-text search with optional t
 
 **Response**:
 
-Returns an array of matching entities:
+Returns an array of matching entities ranked by multi-factor score (relevance, recency, frequency, confidence, temporal validity):
 
 ```json
 [
@@ -116,6 +116,19 @@ Returns an array of matching entities:
   }
 ]
 ```
+
+**Conflict detection**: When any pair of returned entities have a `contradicts` relation, the response is wrapped as:
+
+```json
+{
+  "entities": [...],
+  "conflicts": [
+    "\"no-jwt\" contradicts \"use-jwt\""
+  ]
+}
+```
+
+The CLI prints conflict warnings below the results; the `--json` flag outputs the wrapped form.
 
 **Examples**:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "memesh",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
   "author": { "name": "PCIRCLE AI" },
-  "version": "2.14.0",
+  "version": "2.15.0",
   "homepage": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -102,6 +102,20 @@ export function detectCapabilities(config?: MeMeshConfig): Capabilities {
   };
 }
 
+// --- Startup Capability Logging ---
+
+/**
+ * Log detected capabilities to stderr on server startup.
+ * Uses stderr so it doesn't interfere with MCP stdio transport.
+ */
+export function logCapabilities(config?: MeMeshConfig): void {
+  const caps = detectCapabilities(config);
+  process.stderr.write(`MeMesh: Level ${caps.searchLevel} (${caps.searchLevel === 1 ? 'Smart Mode' : 'Core'})\n`);
+  if (caps.llm) {
+    process.stderr.write(`MeMesh: LLM: ${caps.llm.provider} (${caps.llm.model ?? 'default'})\n`);
+  }
+}
+
 // --- Config Path Exports (for testing) ---
 
 export function getConfigDir(): string { return CONFIG_DIR; }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -11,6 +11,7 @@
 
 import { getDatabase } from '../db.js';
 import { KnowledgeGraph } from '../knowledge-graph.js';
+import { expandQuery, isExpansionAvailable } from './query-expander.js';
 import type {
   RememberInput,
   RememberResult,
@@ -84,6 +85,49 @@ export function recall(args: RecallInput): Entity[] {
   const db = getDatabase();
   const kg = new KnowledgeGraph(db);
 
+  return kg.search(args.query, {
+    tag: args.tag,
+    limit: args.limit,
+    includeArchived: args.include_archived,
+  });
+}
+
+/**
+ * Enhanced recall with optional LLM query expansion (async, Level 1).
+ * When an LLM is configured, expands the query into related terms before searching.
+ * Merges results from all expanded terms, de-duped by entity name.
+ * Falls back to regular sync recall if expansion is unavailable or fails.
+ */
+export async function recallEnhanced(args: RecallInput): Promise<Entity[]> {
+  const db = getDatabase();
+  const kg = new KnowledgeGraph(db);
+
+  if (args.query && isExpansionAvailable()) {
+    try {
+      const expandedTerms = await expandQuery(args.query);
+      // Search with each expanded term and merge results (de-duped by name)
+      const allResults = new Map<string, Entity>();
+
+      for (const term of expandedTerms) {
+        const results = kg.search(term, {
+          tag: args.tag,
+          limit: args.limit,
+          includeArchived: args.include_archived,
+        });
+        for (const entity of results) {
+          if (!allResults.has(entity.name)) {
+            allResults.set(entity.name, entity);
+          }
+        }
+      }
+
+      return [...allResults.values()].slice(0, args.limit ?? 20);
+    } catch {
+      // Fallback to regular search on any expansion error
+    }
+  }
+
+  // Level 0: regular FTS5 search (no LLM expansion)
   return kg.search(args.query, {
     tag: args.tag,
     limit: args.limit,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -12,6 +12,7 @@
 import { getDatabase } from '../db.js';
 import { KnowledgeGraph } from '../knowledge-graph.js';
 import { expandQuery, isExpansionAvailable } from './query-expander.js';
+import { rankEntities } from './scoring.js';
 import type {
   RememberInput,
   RememberResult,
@@ -79,23 +80,33 @@ export function remember(args: RememberInput): RememberResult {
 /**
  * Search and retrieve stored knowledge.
  * Uses FTS5 full-text search with optional tag filtering.
+ * Results are ranked by multi-factor score (recency, frequency, confidence, temporal validity).
  * Empty query returns recent entities.
  */
 export function recall(args: RecallInput): Entity[] {
   const db = getDatabase();
   const kg = new KnowledgeGraph(db);
 
-  return kg.search(args.query, {
+  const entities = kg.search(args.query, {
     tag: args.tag,
     limit: args.limit,
     includeArchived: args.include_archived,
   });
+
+  // Build relevance map: FTS results get 1.0 relevance, recent-list gets 0.5
+  const relevanceMap = new Map<string, number>();
+  for (const e of entities) {
+    relevanceMap.set(e.name, args.query ? 1.0 : 0.5);
+  }
+
+  return rankEntities(entities, relevanceMap).slice(0, args.limit ?? 20);
 }
 
 /**
  * Enhanced recall with optional LLM query expansion (async, Level 1).
  * When an LLM is configured, expands the query into related terms before searching.
  * Merges results from all expanded terms, de-duped by entity name.
+ * Results are ranked by multi-factor score (relevance, recency, frequency, confidence, temporal validity).
  * Falls back to regular sync recall if expansion is unavailable or fails.
  */
 export async function recallEnhanced(args: RecallInput): Promise<Entity[]> {
@@ -105,11 +116,14 @@ export async function recallEnhanced(args: RecallInput): Promise<Entity[]> {
   if (args.query && isExpansionAvailable()) {
     try {
       const expandedTerms = await expandQuery(args.query);
-      // Search with each expanded term and merge results (de-duped by name)
+      // Search with each expanded term and merge results (de-duped by name).
+      // First term (original query) gets 1.0 relevance, expanded terms get 0.7.
       const allResults = new Map<string, Entity>();
+      const relevanceMap = new Map<string, number>();
 
-      for (const term of expandedTerms) {
-        const results = kg.search(term, {
+      for (let i = 0; i < expandedTerms.length; i++) {
+        const termRelevance = i === 0 ? 1.0 : 0.7;
+        const results = kg.search(expandedTerms[i], {
           tag: args.tag,
           limit: args.limit,
           includeArchived: args.include_archived,
@@ -118,21 +132,35 @@ export async function recallEnhanced(args: RecallInput): Promise<Entity[]> {
           if (!allResults.has(entity.name)) {
             allResults.set(entity.name, entity);
           }
+          // Keep the highest relevance if found by multiple terms
+          const existing = relevanceMap.get(entity.name) ?? 0;
+          if (termRelevance > existing) {
+            relevanceMap.set(entity.name, termRelevance);
+          }
         }
       }
 
-      return [...allResults.values()].slice(0, args.limit ?? 20);
+      const merged = [...allResults.values()];
+      return rankEntities(merged, relevanceMap).slice(0, args.limit ?? 20);
     } catch {
       // Fallback to regular search on any expansion error
     }
   }
 
   // Level 0: regular FTS5 search (no LLM expansion)
-  return kg.search(args.query, {
+  const entities = kg.search(args.query, {
     tag: args.tag,
     limit: args.limit,
     includeArchived: args.include_archived,
   });
+
+  // Build relevance map: FTS results get 1.0, recent-list gets 0.5
+  const relevanceMap = new Map<string, number>();
+  for (const e of entities) {
+    relevanceMap.set(e.name, args.query ? 1.0 : 0.5);
+  }
+
+  return rankEntities(entities, relevanceMap).slice(0, args.limit ?? 20);
 }
 
 /**

--- a/src/core/query-expander.ts
+++ b/src/core/query-expander.ts
@@ -1,0 +1,135 @@
+import { detectCapabilities } from './config.js';
+import type { LLMConfig } from './config.js';
+
+/**
+ * Expand a search query into related keywords using an LLM.
+ * Returns an array of search terms (original + expanded).
+ * Falls back to [query] if LLM is unavailable or fails.
+ */
+export async function expandQuery(query: string): Promise<string[]> {
+  const caps = detectCapabilities();
+  if (!caps.llm) return [query]; // Level 0: no expansion
+
+  try {
+    const expanded = await callLLMForExpansion(query, caps.llm);
+    // Always include the original query so it's searched verbatim too
+    if (!expanded.includes(query)) {
+      expanded.unshift(query);
+    }
+    return expanded;
+  } catch {
+    return [query]; // Graceful fallback
+  }
+}
+
+async function callLLMForExpansion(query: string, config: LLMConfig): Promise<string[]> {
+  const prompt = `Given the search query "${query}", generate a list of 5-10 related keywords and synonyms that someone might use to describe the same concept. Return ONLY a JSON array of strings, no explanation. Example: ["keyword1", "keyword2", ...]`;
+
+  if (config.provider === 'anthropic') {
+    return await callAnthropic(prompt, config);
+  } else if (config.provider === 'openai') {
+    return await callOpenAI(prompt, config);
+  } else if (config.provider === 'ollama') {
+    return await callOllama(prompt, config);
+  }
+  return [query];
+}
+
+async function callAnthropic(prompt: string, config: LLMConfig): Promise<string[]> {
+  const apiKey = config.apiKey || process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return [];
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: config.model || 'claude-haiku-4-5',
+      max_tokens: 200,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!response.ok) throw new Error(`Anthropic API error: ${response.status}`);
+  const data = await response.json() as any;
+  const text = data.content?.[0]?.text || '[]';
+  return parseKeywords(text);
+}
+
+async function callOpenAI(prompt: string, config: LLMConfig): Promise<string[]> {
+  const apiKey = config.apiKey || process.env.OPENAI_API_KEY;
+  if (!apiKey) return [];
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: config.model || 'gpt-4o-mini',
+      max_tokens: 200,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!response.ok) throw new Error(`OpenAI API error: ${response.status}`);
+  const data = await response.json() as any;
+  const text = data.choices?.[0]?.message?.content || '[]';
+  return parseKeywords(text);
+}
+
+async function callOllama(prompt: string, config: LLMConfig): Promise<string[]> {
+  const host = process.env.OLLAMA_HOST || 'http://localhost:11434';
+
+  const response = await fetch(`${host}/api/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: config.model || 'llama3.2',
+      prompt,
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) throw new Error(`Ollama error: ${response.status}`);
+  const data = await response.json() as any;
+  return parseKeywords(data.response || '[]');
+}
+
+/**
+ * Parse keyword list from LLM response text.
+ * Handles JSON arrays, comma-separated, newline-separated, and malformed output.
+ * Exported for testing.
+ */
+export function parseKeywords(text: string): string[] {
+  // Try to extract JSON array from the response
+  try {
+    const match = text.match(/\[[\s\S]*?\]/);
+    if (match) {
+      const arr = JSON.parse(match[0]);
+      if (Array.isArray(arr)) {
+        return arr
+          .filter((k: any) => typeof k === 'string' && k.length > 0)
+          .slice(0, 15);
+      }
+    }
+  } catch {}
+  // Fallback: split by commas or newlines, strip JSON-like artifacts
+  return text
+    .split(/[,\n]+/)
+    .map((s) => s.trim().replace(/["\[\]]/g, ''))
+    .filter((s) => s.length > 1)
+    .slice(0, 15);
+}
+
+/**
+ * Check if LLM query expansion is available (Level 1).
+ */
+export function isExpansionAvailable(): boolean {
+  const caps = detectCapabilities();
+  return caps.llm !== null;
+}

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -1,0 +1,81 @@
+export interface ScoringWeights {
+  searchRelevance: number;   // default 0.35
+  recency: number;           // default 0.25
+  frequency: number;         // default 0.20
+  confidence: number;        // default 0.15
+  temporalValidity: number;  // default 0.05
+}
+
+export const DEFAULT_WEIGHTS: ScoringWeights = {
+  searchRelevance: 0.35,
+  recency: 0.25,
+  frequency: 0.20,
+  confidence: 0.15,
+  temporalValidity: 0.05,
+};
+
+/**
+ * Calculate recency score using exponential decay.
+ * Score = e^(-days_since_access / 30)
+ * Recent = 1.0, 30 days = 0.37, 60 days = 0.14, 90 days = 0.05
+ */
+export function recencyScore(lastAccessedAt: string | null | undefined): number {
+  if (!lastAccessedAt) return 0.5; // neutral if never accessed
+  const days = (Date.now() - new Date(lastAccessedAt).getTime()) / (1000 * 60 * 60 * 24);
+  return Math.exp(-days / 30);
+}
+
+/**
+ * Calculate frequency score using log normalization.
+ * Score = log(access_count + 1) / log(maxAccess + 1)
+ */
+export function frequencyScore(accessCount: number, maxAccessCount: number): number {
+  if (maxAccessCount <= 0) return 0;
+  return Math.log(accessCount + 1) / Math.log(maxAccessCount + 1);
+}
+
+/**
+ * Calculate temporal validity score.
+ * 1.0 if currently valid (no valid_until or valid_until > now)
+ * 0.5 if expired (valid_until < now)
+ */
+export function temporalValidityScore(validUntil: string | null | undefined): number {
+  if (!validUntil) return 1.0; // no expiry = always valid
+  return new Date(validUntil).getTime() > Date.now() ? 1.0 : 0.5;
+}
+
+/**
+ * Score a single entity.
+ * searchRelevanceValue is provided by the search engine (FTS5 rank or vector distance).
+ */
+export function scoreEntity(
+  entity: { access_count?: number; last_accessed_at?: string; confidence?: number; valid_until?: string },
+  searchRelevanceValue: number,
+  maxAccessCount: number,
+  weights: ScoringWeights = DEFAULT_WEIGHTS
+): number {
+  const sr = searchRelevanceValue * weights.searchRelevance;
+  const rc = recencyScore(entity.last_accessed_at) * weights.recency;
+  const fq = frequencyScore(entity.access_count ?? 0, maxAccessCount) * weights.frequency;
+  const cf = (entity.confidence ?? 1.0) * weights.confidence;
+  const tv = temporalValidityScore(entity.valid_until) * weights.temporalValidity;
+  return sr + rc + fq + cf + tv;
+}
+
+/**
+ * Sort entities by score descending.
+ * searchRelevanceValues maps entity name → search relevance (0-1).
+ */
+export function rankEntities<T extends { name: string; access_count?: number; last_accessed_at?: string; confidence?: number; valid_until?: string }>(
+  entities: T[],
+  searchRelevanceValues: Map<string, number>,
+  weights?: ScoringWeights
+): T[] {
+  const maxAccess = Math.max(...entities.map(e => e.access_count ?? 0), 1);
+
+  return [...entities].sort((a, b) => {
+    const scoreA = scoreEntity(a, searchRelevanceValues.get(a.name) ?? 0.5, maxAccess, weights);
+    const scoreB = scoreEntity(b, searchRelevanceValues.get(b.name) ?? 0.5, maxAccess, weights);
+    return scoreB - scoreA;
+  });
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,6 +15,11 @@ export interface Entity {
   tags: string[];
   relations?: Relation[];
   archived?: boolean;
+  access_count?: number;
+  last_accessed_at?: string;
+  confidence?: number;
+  valid_from?: string;
+  valid_until?: string;
 }
 
 export interface Relation {

--- a/src/db.ts
+++ b/src/db.ts
@@ -86,6 +86,16 @@ export function openDatabase(dbPath?: string): Database.Database {
     db.exec("CREATE INDEX IF NOT EXISTS idx_entities_status ON entities(status)");
   }
 
+  // Migrate: add scoring columns if missing (v2.14 -> v2.15)
+  const scoringCols = db.prepare("PRAGMA table_info(entities)").all() as any[];
+  if (!scoringCols.some((c: any) => c.name === 'access_count')) {
+    db.exec("ALTER TABLE entities ADD COLUMN access_count INTEGER DEFAULT 0");
+    db.exec("ALTER TABLE entities ADD COLUMN last_accessed_at TIMESTAMP");
+    db.exec("ALTER TABLE entities ADD COLUMN confidence REAL DEFAULT 1.0");
+    db.exec("ALTER TABLE entities ADD COLUMN valid_from TIMESTAMP");
+    db.exec("ALTER TABLE entities ADD COLUMN valid_until TIMESTAMP");
+  }
+
   // Load sqlite-vec extension for vector similarity search
   sqliteVec.load(db);
 

--- a/src/knowledge-graph.ts
+++ b/src/knowledge-graph.ts
@@ -265,7 +265,27 @@ export class KnowledgeGraph {
       }
     }
 
+    const entityIds = results.map((e) => e.id);
+    this.trackAccess(entityIds);
     return results;
+  }
+
+  /**
+   * Increment access_count and update last_accessed_at for entities.
+   * Called after search/recall returns results.
+   */
+  trackAccess(entityIds: number[]): void {
+    if (entityIds.length === 0) return;
+    const now = new Date().toISOString();
+    const stmt = this.db.prepare(
+      'UPDATE entities SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?'
+    );
+    const txn = this.db.transaction(() => {
+      for (const id of entityIds) {
+        stmt.run(now, id);
+      }
+    });
+    txn();
   }
 
   listRecent(limit?: number, includeArchived?: boolean): Entity[] {
@@ -274,9 +294,13 @@ export class KnowledgeGraph {
       .prepare(`SELECT name FROM entities ${statusFilter} ORDER BY id DESC LIMIT ?`)
       .all(limit ?? 20) as { name: string }[];
 
-    return rows
+    const results = rows
       .map((r) => this.getEntity(r.name))
       .filter((e): e is Entity => e !== null);
+
+    const entityIds = results.map((e) => e.id);
+    this.trackAccess(entityIds);
+    return results;
   }
 
   private listRecentByTag(tag: string, limit: number, includeArchived?: boolean): Entity[] {
@@ -293,9 +317,13 @@ export class KnowledgeGraph {
       )
       .all(tag, limit) as { name: string }[];
 
-    return rows
+    const results = rows
       .map((r) => this.getEntity(r.name))
       .filter((e): e is Entity => e !== null);
+
+    const entityIds = results.map((e) => e.id);
+    this.trackAccess(entityIds);
+    return results;
   }
 
   archiveEntity(name: string): { archived: boolean; name?: string; previousStatus?: string } {

--- a/src/knowledge-graph.ts
+++ b/src/knowledge-graph.ts
@@ -288,6 +288,33 @@ export class KnowledgeGraph {
     txn();
   }
 
+  /**
+   * Find contradicting entity pairs in a set of results.
+   * Returns array of conflict descriptions.
+   */
+  findConflicts(entityNames: string[]): string[] {
+    if (entityNames.length < 2) return [];
+
+    const conflicts: string[] = [];
+    const placeholders = entityNames.map(() => '?').join(',');
+
+    const rows = this.db.prepare(`
+      SELECT e_from.name AS from_name, e_to.name AS to_name
+      FROM relations r
+      JOIN entities e_from ON r.from_entity_id = e_from.id
+      JOIN entities e_to ON r.to_entity_id = e_to.id
+      WHERE r.relation_type = 'contradicts'
+        AND e_from.name IN (${placeholders})
+        AND e_to.name IN (${placeholders})
+    `).all(...entityNames, ...entityNames) as any[];
+
+    for (const row of rows) {
+      conflicts.push(`"${row.from_name}" contradicts "${row.to_name}"`);
+    }
+
+    return conflicts;
+  }
+
   listRecent(limit?: number, includeArchived?: boolean): Entity[] {
     const statusFilter = includeArchived ? '' : "WHERE status = 'active'";
     const rows = this.db

--- a/src/knowledge-graph.ts
+++ b/src/knowledge-graph.ts
@@ -116,7 +116,9 @@ export class KnowledgeGraph {
 
   getEntity(name: string): Entity | null {
     const row = this.db
-      .prepare('SELECT id, name, type, created_at, metadata, status FROM entities WHERE name = ?')
+      .prepare(
+        'SELECT id, name, type, created_at, metadata, status, access_count, last_accessed_at, confidence, valid_from, valid_until FROM entities WHERE name = ?'
+      )
       .get(name) as any | undefined;
 
     if (!row) return null;
@@ -143,6 +145,11 @@ export class KnowledgeGraph {
       tags,
       relations: relations.length > 0 ? relations : undefined,
       ...(row.status === 'archived' ? { archived: true } : {}),
+      access_count: row.access_count ?? 0,
+      last_accessed_at: row.last_accessed_at ?? undefined,
+      confidence: row.confidence ?? 1.0,
+      valid_from: row.valid_from ?? undefined,
+      valid_until: row.valid_until ?? undefined,
     };
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,7 @@ import {
 import { fileURLToPath } from 'url';
 import { openDatabase, closeDatabase } from '../db.js';
 import { handleTool, TOOL_DEFINITIONS } from './tools.js';
+import { logCapabilities } from '../core/config.js';
 
 const packageJsonPath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -42,6 +43,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 // Start
 async function main() {
   openDatabase();
+  logCapabilities();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/transports/cli/cli.ts
+++ b/src/transports/cli/cli.ts
@@ -4,8 +4,9 @@ import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { openDatabase, closeDatabase } from '../../db.js';
+import { openDatabase, closeDatabase, getDatabase } from '../../db.js';
 import { remember, recallEnhanced, forget } from '../../core/operations.js';
+import { KnowledgeGraph } from '../../knowledge-graph.js';
 import { readConfig, updateConfig, maskApiKey, detectCapabilities } from '../../core/config.js';
 
 const packageJsonPath = path.resolve(
@@ -67,8 +68,15 @@ program
         limit: parseInt(opts.limit),
         include_archived: opts.includeArchived,
       });
+      const kg = new KnowledgeGraph(getDatabase());
+      const conflicts = kg.findConflicts(entities.map(e => e.name));
+
       if (opts.json) {
-        console.log(JSON.stringify(entities));
+        if (conflicts.length > 0) {
+          console.log(JSON.stringify({ entities, conflicts }));
+        } else {
+          console.log(JSON.stringify(entities));
+        }
       } else if (entities.length === 0) {
         console.log('No results found.');
       } else {
@@ -83,6 +91,12 @@ program
           }
         }
         console.log(`\n${entities.length} result(s)`);
+        if (conflicts.length > 0) {
+          console.log('\nWarning: Conflicts detected:');
+          for (const c of conflicts) {
+            console.log(`  ${c}`);
+          }
+        }
       }
     } finally {
       closeDatabase();

--- a/src/transports/cli/cli.ts
+++ b/src/transports/cli/cli.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { openDatabase, closeDatabase } from '../../db.js';
-import { remember, recall, forget } from '../../core/operations.js';
+import { remember, recallEnhanced, forget } from '../../core/operations.js';
 import { readConfig, updateConfig, maskApiKey, detectCapabilities } from '../../core/config.js';
 
 const packageJsonPath = path.resolve(
@@ -57,10 +57,11 @@ program
   .option('--limit <n>', 'Max results', '20')
   .option('--include-archived', 'Include archived entities')
   .option('--json', 'Output as JSON')
-  .action((query, opts) => {
+  .action(async (query, opts) => {
     openDatabase();
     try {
-      const entities = recall({
+      // recallEnhanced: uses LLM query expansion when configured, falls back otherwise
+      const entities = await recallEnhanced({
         query: query || undefined,
         tag: opts.tag,
         limit: parseInt(opts.limit),

--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -3,7 +3,7 @@
 import express from 'express';
 import { z } from 'zod';
 import { openDatabase, closeDatabase } from '../../db.js';
-import { remember, recall, forget } from '../../core/operations.js';
+import { remember, recallEnhanced, forget } from '../../core/operations.js';
 import { KnowledgeGraph } from '../../knowledge-graph.js';
 import { getDatabase } from '../../db.js';
 
@@ -68,14 +68,15 @@ app.post('/v1/remember', (req, res) => {
 });
 
 // --- Recall ---
-app.post('/v1/recall', (req, res) => {
+app.post('/v1/recall', async (req, res) => {
   const parsed = RecallBody.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ success: false, error: parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ') });
     return;
   }
   try {
-    const entities = recall(parsed.data);
+    // recallEnhanced: uses LLM query expansion when configured, falls back otherwise
+    const entities = await recallEnhanced(parsed.data);
     res.json({ success: true, data: entities });
   } catch (err: any) {
     res.status(400).json({ success: false, error: err.message });

--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -6,6 +6,7 @@ import { openDatabase, closeDatabase } from '../../db.js';
 import { remember, recallEnhanced, forget } from '../../core/operations.js';
 import { KnowledgeGraph } from '../../knowledge-graph.js';
 import { getDatabase } from '../../db.js';
+import { logCapabilities } from '../../core/config.js';
 
 // Zod schemas for HTTP input validation (same rules as MCP handlers)
 const RememberBody = z.object({
@@ -77,7 +78,13 @@ app.post('/v1/recall', async (req, res) => {
   try {
     // recallEnhanced: uses LLM query expansion when configured, falls back otherwise
     const entities = await recallEnhanced(parsed.data);
-    res.json({ success: true, data: entities });
+    const kg = new KnowledgeGraph(getDatabase());
+    const conflicts = kg.findConflicts(entities.map(e => e.name));
+    if (conflicts.length > 0) {
+      res.json({ success: true, data: { entities, conflicts } });
+    } else {
+      res.json({ success: true, data: entities });
+    }
   } catch (err: any) {
     res.status(400).json({ success: false, error: err.message });
   }
@@ -134,6 +141,7 @@ const PORT = parseInt(process.env.MEMESH_HTTP_PORT || '3737');
 
 export function startServer(host = HOST, port = PORT): ReturnType<typeof app.listen> {
   openDatabase();
+  logCapabilities();
   const server = app.listen(port, host, () => {
     console.log(`MeMesh HTTP server running at http://${host}:${port}`);
   });

--- a/src/transports/mcp/handlers.ts
+++ b/src/transports/mcp/handlers.ts
@@ -5,7 +5,7 @@
 // =============================================================================
 
 import { z } from 'zod';
-import { remember, recall, forget } from '../../core/operations.js';
+import { remember, recall, recallEnhanced, forget } from '../../core/operations.js';
 
 // ---------------------------------------------------------------------------
 // Zod validation schemas (transport-layer responsibility)
@@ -168,7 +168,7 @@ function parseOrFail<T>(schema: z.ZodType<T>, args: unknown): { ok: true; data: 
   return { ok: true, data: parsed.data };
 }
 
-export function handleTool(name: string, args: any): ToolResult {
+export async function handleTool(name: string, args: any): Promise<ToolResult> {
   try {
     if (name === 'remember') {
       const r = parseOrFail(RememberSchema, args);
@@ -178,7 +178,8 @@ export function handleTool(name: string, args: any): ToolResult {
     if (name === 'recall') {
       const r = parseOrFail(RecallSchema, args);
       if (!r.ok) return r.result;
-      return ok(recall(r.data));
+      // Use recallEnhanced — internally falls back to sync recall if no LLM configured
+      return ok(await recallEnhanced(r.data));
     }
     if (name === 'forget') {
       const r = parseOrFail(ForgetSchema, args);

--- a/src/transports/mcp/handlers.ts
+++ b/src/transports/mcp/handlers.ts
@@ -6,6 +6,8 @@
 
 import { z } from 'zod';
 import { remember, recall, recallEnhanced, forget } from '../../core/operations.js';
+import { KnowledgeGraph } from '../../knowledge-graph.js';
+import { getDatabase } from '../../db.js';
 
 // ---------------------------------------------------------------------------
 // Zod validation schemas (transport-layer responsibility)
@@ -179,7 +181,13 @@ export async function handleTool(name: string, args: any): Promise<ToolResult> {
       const r = parseOrFail(RecallSchema, args);
       if (!r.ok) return r.result;
       // Use recallEnhanced — internally falls back to sync recall if no LLM configured
-      return ok(await recallEnhanced(r.data));
+      const entities = await recallEnhanced(r.data);
+      const kg = new KnowledgeGraph(getDatabase());
+      const conflicts = kg.findConflicts(entities.map(e => e.name));
+      if (conflicts.length > 0) {
+        return ok({ entities, conflicts });
+      }
+      return ok(entities);
     }
     if (name === 'forget') {
       const r = parseOrFail(ForgetSchema, args);

--- a/tests/core/query-expander.test.ts
+++ b/tests/core/query-expander.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { expandQuery, isExpansionAvailable, parseKeywords } from '../../src/core/query-expander.js';
+
+// ---------------------------------------------------------------------------
+// isExpansionAvailable
+// ---------------------------------------------------------------------------
+
+describe('isExpansionAvailable', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      OLLAMA_HOST: process.env.OLLAMA_HOST,
+    };
+  });
+
+  afterEach(() => {
+    // Restore env
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+  });
+
+  it('returns false when no API keys or Ollama host are set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OLLAMA_HOST;
+    // Note: config.json may still provide an LLM config, but in the test environment
+    // the ~/.memesh/config.json typically does not exist, so this should return false.
+    // We cannot guarantee file system state, so we just ensure it's a boolean.
+    expect(typeof isExpansionAvailable()).toBe('boolean');
+  });
+
+  it('returns true when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key-anthropic';
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OLLAMA_HOST;
+    expect(isExpansionAvailable()).toBe(true);
+  });
+
+  it('returns true when OPENAI_API_KEY is set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.OPENAI_API_KEY = 'test-key-openai';
+    delete process.env.OLLAMA_HOST;
+    expect(isExpansionAvailable()).toBe(true);
+  });
+
+  it('returns true when OLLAMA_HOST is set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    process.env.OLLAMA_HOST = 'http://localhost:11434';
+    expect(isExpansionAvailable()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandQuery (no LLM — Level 0 fallback)
+// ---------------------------------------------------------------------------
+
+describe('expandQuery — Level 0 (no LLM)', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      OLLAMA_HOST: process.env.OLLAMA_HOST,
+    };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OLLAMA_HOST;
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+  });
+
+  it('returns [query] when no LLM is configured', async () => {
+    const result = await expandQuery('login security');
+    // Should return at least the original query
+    expect(result).toContain('login security');
+  });
+
+  it('returns array with original query as first element', async () => {
+    const result = await expandQuery('OAuth PKCE');
+    expect(result[0]).toBe('OAuth PKCE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseKeywords
+// ---------------------------------------------------------------------------
+
+describe('parseKeywords', () => {
+  it('parses a clean JSON array', () => {
+    const result = parseKeywords('["authentication", "login", "oauth"]');
+    expect(result).toEqual(['authentication', 'login', 'oauth']);
+  });
+
+  it('parses JSON array embedded in prose', () => {
+    const result = parseKeywords('Here are some keywords: ["auth", "security", "token"]');
+    expect(result).toEqual(['auth', 'security', 'token']);
+  });
+
+  it('handles empty JSON array', () => {
+    const result = parseKeywords('[]');
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to comma splitting on non-JSON text', () => {
+    const result = parseKeywords('auth, security, token, login');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('auth');
+    expect(result).toContain('security');
+  });
+
+  it('falls back to newline splitting on newline-separated text', () => {
+    const result = parseKeywords('auth\nsecurity\ntoken\nlogin');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('auth');
+  });
+
+  it('strips JSON artifacts in fallback path', () => {
+    const result = parseKeywords('"auth", "security", "token"');
+    // After stripping quotes, should not have raw quotes
+    for (const kw of result) {
+      expect(kw).not.toContain('"');
+    }
+  });
+
+  it('filters out empty strings', () => {
+    const result = parseKeywords('["auth", "", "security"]');
+    expect(result).not.toContain('');
+  });
+
+  it('caps results at 15 keywords', () => {
+    const many = Array.from({ length: 20 }, (_, i) => `keyword${i}`);
+    const result = parseKeywords(JSON.stringify(many));
+    expect(result.length).toBeLessThanOrEqual(15);
+  });
+
+  it('handles completely malformed input gracefully', () => {
+    // Should not throw
+    expect(() => parseKeywords('{ not valid json at all ###')).not.toThrow();
+    const result = parseKeywords('{ not valid json at all ###');
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('handles empty string input', () => {
+    const result = parseKeywords('');
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('filters out single-character strings in fallback path', () => {
+    // The comma-split fallback uses s.length > 1
+    const result = parseKeywords('a, auth, b, security');
+    expect(result).not.toContain('a');
+    expect(result).not.toContain('b');
+    expect(result).toContain('auth');
+    expect(result).toContain('security');
+  });
+});

--- a/tests/core/scoring.test.ts
+++ b/tests/core/scoring.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { recencyScore, frequencyScore, temporalValidityScore, scoreEntity, rankEntities, DEFAULT_WEIGHTS } from '../../src/core/scoring.js';
+
+describe('Scoring Engine', () => {
+  describe('recencyScore', () => {
+    it('returns 1.0 for just-accessed entity', () => {
+      expect(recencyScore(new Date().toISOString())).toBeCloseTo(1.0, 1);
+    });
+
+    it('returns ~0.37 for 30-day-old access', () => {
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      expect(recencyScore(thirtyDaysAgo)).toBeCloseTo(0.37, 1);
+    });
+
+    it('returns 0.5 for null access', () => {
+      expect(recencyScore(null)).toBe(0.5);
+    });
+  });
+
+  describe('frequencyScore', () => {
+    it('returns 0 for zero access', () => {
+      expect(frequencyScore(0, 100)).toBeCloseTo(0, 1);
+    });
+
+    it('returns 1.0 for max access', () => {
+      expect(frequencyScore(100, 100)).toBeCloseTo(1.0, 1);
+    });
+
+    it('returns ~0.5 for sqrt(max) access', () => {
+      expect(frequencyScore(10, 100)).toBeGreaterThan(0.3);
+      expect(frequencyScore(10, 100)).toBeLessThan(0.7);
+    });
+  });
+
+  describe('temporalValidityScore', () => {
+    it('returns 1.0 for no expiry', () => {
+      expect(temporalValidityScore(null)).toBe(1.0);
+    });
+
+    it('returns 1.0 for future expiry', () => {
+      const future = new Date(Date.now() + 86400000).toISOString();
+      expect(temporalValidityScore(future)).toBe(1.0);
+    });
+
+    it('returns 0.5 for past expiry', () => {
+      const past = new Date(Date.now() - 86400000).toISOString();
+      expect(temporalValidityScore(past)).toBe(0.5);
+    });
+  });
+
+  describe('rankEntities', () => {
+    it('ranks frequently accessed higher', () => {
+      const entities = [
+        { name: 'rare', access_count: 1, confidence: 1.0 },
+        { name: 'popular', access_count: 50, confidence: 1.0 },
+      ];
+      const relevance = new Map([['rare', 0.5], ['popular', 0.5]]);
+      const ranked = rankEntities(entities, relevance);
+      expect(ranked[0].name).toBe('popular');
+    });
+
+    it('ranks recent higher when access is equal', () => {
+      const now = new Date().toISOString();
+      const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const entities = [
+        { name: 'old', access_count: 5, last_accessed_at: old, confidence: 1.0 },
+        { name: 'recent', access_count: 5, last_accessed_at: now, confidence: 1.0 },
+      ];
+      const relevance = new Map([['old', 0.5], ['recent', 0.5]]);
+      const ranked = rankEntities(entities, relevance);
+      expect(ranked[0].name).toBe('recent');
+    });
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -138,4 +138,30 @@ describe('Feature: Database Management', () => {
       expect(tables).toHaveLength(1);
     });
   });
+
+  describe('Scenario: Scoring and temporal columns migration (v2.14 -> v2.15)', () => {
+    it('should have access_count column with default 0', () => {
+      const db = openDatabase(testDbPath);
+      const info = db.prepare("PRAGMA table_info(entities)").all() as any[];
+      const col = info.find((c: any) => c.name === 'access_count');
+      expect(col).toBeDefined();
+      expect(col.dflt_value).toBe('0');
+    });
+
+    it('should have confidence column with default 1.0', () => {
+      const db = openDatabase(testDbPath);
+      const info = db.prepare("PRAGMA table_info(entities)").all() as any[];
+      const col = info.find((c: any) => c.name === 'confidence');
+      expect(col).toBeDefined();
+      expect(col.dflt_value).toBe('1.0');
+    });
+
+    it('should have temporal columns (valid_from, valid_until, last_accessed_at)', () => {
+      const db = openDatabase(testDbPath);
+      const info = db.prepare("PRAGMA table_info(entities)").all() as any[];
+      expect(info.some((c: any) => c.name === 'valid_from')).toBe(true);
+      expect(info.some((c: any) => c.name === 'valid_until')).toBe(true);
+      expect(info.some((c: any) => c.name === 'last_accessed_at')).toBe(true);
+    });
+  });
 });

--- a/tests/knowledge-graph.test.ts
+++ b/tests/knowledge-graph.test.ts
@@ -497,6 +497,56 @@ describe('Feature: Knowledge Graph', () => {
     });
   });
 
+  describe('Conflict Detection', () => {
+    it('should detect contradicting entities', () => {
+      kg.createEntity('use-jwt', 'decision', { observations: ['Always use JWT'] });
+      kg.createEntity('no-jwt', 'decision', { observations: ['Never use JWT'] });
+      kg.createRelation('no-jwt', 'use-jwt', 'contradicts');
+
+      const conflicts = kg.findConflicts(['use-jwt', 'no-jwt']);
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0]).toContain('contradicts');
+    });
+
+    it('should return empty for non-conflicting entities', () => {
+      kg.createEntity('a', 'note');
+      kg.createEntity('b', 'note');
+
+      const conflicts = kg.findConflicts(['a', 'b']);
+      expect(conflicts).toEqual([]);
+    });
+
+    it('should handle single entity', () => {
+      expect(kg.findConflicts(['a'])).toEqual([]);
+    });
+
+    it('should handle empty array', () => {
+      expect(kg.findConflicts([])).toEqual([]);
+    });
+
+    it('should not flag non-contradicts relations as conflicts', () => {
+      kg.createEntity('ParentA', 'decision');
+      kg.createEntity('ChildB', 'decision');
+      kg.createRelation('ParentA', 'ChildB', 'relates-to');
+
+      const conflicts = kg.findConflicts(['ParentA', 'ChildB']);
+      expect(conflicts).toEqual([]);
+    });
+
+    it('should detect both directions of contradicts', () => {
+      kg.createEntity('X', 'decision', { observations: ['prefer X'] });
+      kg.createEntity('Y', 'decision', { observations: ['prefer Y'] });
+      kg.createEntity('Z', 'decision', { observations: ['prefer Z'] });
+      kg.createRelation('X', 'Y', 'contradicts');
+      kg.createRelation('Z', 'Y', 'contradicts');
+
+      const conflicts = kg.findConflicts(['X', 'Y', 'Z']);
+      expect(conflicts).toHaveLength(2);
+      expect(conflicts.some((c) => c.includes('"X" contradicts "Y"'))).toBe(true);
+      expect(conflicts.some((c) => c.includes('"Z" contradicts "Y"'))).toBe(true);
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should throw when creating relation with non-existent entity', () => {
       kg.createEntity('Exists', 'test');

--- a/tests/knowledge-graph.test.ts
+++ b/tests/knowledge-graph.test.ts
@@ -448,6 +448,55 @@ describe('Feature: Knowledge Graph', () => {
     });
   });
 
+  describe('Access Tracking', () => {
+    it('should increment access_count on search', () => {
+      kg.createEntity('Test', 'note', { observations: ['some data'] });
+
+      // Before search
+      const before = kg.getEntity('Test');
+      expect(before!.access_count).toBe(0);
+
+      // Search (triggers trackAccess)
+      kg.search('data');
+
+      // After search
+      const after = kg.getEntity('Test');
+      expect(after!.access_count).toBe(1);
+      expect(after!.last_accessed_at).toBeDefined();
+    });
+
+    it('should increment on each recall', () => {
+      kg.createEntity('Multi', 'note', { observations: ['test data'] });
+      kg.search('test');
+      kg.search('test');
+      kg.search('test');
+
+      const entity = kg.getEntity('Multi');
+      expect(entity!.access_count).toBe(3);
+    });
+
+    it('should increment access_count on listRecent', () => {
+      kg.createEntity('RecentEntity', 'note', { observations: ['content'] });
+
+      const before = kg.getEntity('RecentEntity');
+      expect(before!.access_count).toBe(0);
+
+      kg.listRecent();
+
+      const after = kg.getEntity('RecentEntity');
+      expect(after!.access_count).toBe(1);
+    });
+
+    it('should increment access_count when search falls back to listRecent (empty query)', () => {
+      kg.createEntity('FallbackTest', 'note', { observations: ['data'] });
+
+      kg.search('');
+
+      const entity = kg.getEntity('FallbackTest');
+      expect(entity!.access_count).toBe(1);
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should throw when creating relation with non-existent entity', () => {
       kg.createEntity('Exists', 'test');

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -22,8 +22,8 @@ afterEach(() => {
 // ── Remember ────────────────────────────────────────────────────────────
 
 describe('remember', () => {
-  it('stores an entity and returns confirmation', () => {
-    const result = handleTool('remember', {
+  it('stores an entity and returns confirmation', async () => {
+    const result = await handleTool('remember', {
       name: 'auth-decision',
       type: 'decision',
     });
@@ -35,11 +35,11 @@ describe('remember', () => {
     expect(data.type).toBe('decision');
   });
 
-  it('stores tags and relations', () => {
+  it('stores tags and relations', async () => {
     // Create target entity first so relation can be established
-    handleTool('remember', { name: 'jwt-pattern', type: 'pattern' });
+    await handleTool('remember', { name: 'jwt-pattern', type: 'pattern' });
 
-    const result = handleTool('remember', {
+    const result = await handleTool('remember', {
       name: 'auth-decision',
       type: 'decision',
       tags: ['project:myapp', 'type:decision'],
@@ -52,60 +52,60 @@ describe('remember', () => {
     expect(data.relations).toBe(1);
   });
 
-  it('returns validation error when name is missing', () => {
-    const result = handleTool('remember', { type: 'decision' });
+  it('returns validation error when name is missing', async () => {
+    const result = await handleTool('remember', { type: 'decision' });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('name');
   });
 
-  it('returns validation error when name is empty', () => {
-    const result = handleTool('remember', { name: '', type: 'decision' });
+  it('returns validation error when name is empty', async () => {
+    const result = await handleTool('remember', { name: '', type: 'decision' });
 
     expect(result.isError).toBe(true);
   });
 
-  it('stores observations that are searchable', () => {
-    handleTool('remember', {
+  it('stores observations that are searchable', async () => {
+    await handleTool('remember', {
       name: 'jwt-lesson',
       type: 'lesson',
       observations: ['Use RS256 for JWT signing', 'Rotate keys quarterly'],
     });
 
-    const result = handleTool('recall', { query: 'RS256' });
+    const result = await handleTool('recall', { query: 'RS256' });
     const data = JSON.parse(result.content[0].text);
     expect(data.length).toBe(1);
     expect(data[0].name).toBe('jwt-lesson');
     expect(data[0].observations).toContain('Use RS256 for JWT signing');
   });
 
-  it('auto-archives entity when superseded by new remember', () => {
-    handleTool('remember', { name: 'auth-v2', type: 'decision', observations: ['Use JWT'] });
-    handleTool('remember', {
+  it('auto-archives entity when superseded by new remember', async () => {
+    await handleTool('remember', { name: 'auth-v2', type: 'decision', observations: ['Use JWT'] });
+    await handleTool('remember', {
       name: 'auth-v3', type: 'decision', observations: ['Use OAuth 2.0'],
       relations: [{ to: 'auth-v2', type: 'supersedes' }],
     });
 
     // auth-v2 should be auto-archived
-    const recallOld = handleTool('recall', { query: 'JWT' });
+    const recallOld = await handleTool('recall', { query: 'JWT' });
     expect(JSON.parse(recallOld.content[0].text)).toEqual([]);
 
     // auth-v3 should be active
-    const recallNew = handleTool('recall', { query: 'OAuth' });
+    const recallNew = await handleTool('recall', { query: 'OAuth' });
     const data = JSON.parse(recallNew.content[0].text);
     expect(data).toHaveLength(1);
     expect(data[0].name).toBe('auth-v3');
 
     // Both visible with include_archived
-    const recallAll = handleTool('recall', { include_archived: true });
+    const recallAll = await handleTool('recall', { include_archived: true });
     const allData = JSON.parse(recallAll.content[0].text);
     const names = allData.map((e: any) => e.name);
     expect(names).toContain('auth-v2');
     expect(names).toContain('auth-v3');
   });
 
-  it('reports relation errors without failing overall', () => {
-    const result = handleTool('remember', {
+  it('reports relation errors without failing overall', async () => {
+    const result = await handleTool('remember', {
       name: 'auth-decision',
       type: 'decision',
       relations: [{ to: 'nonexistent-entity', type: 'related-to' }],
@@ -122,14 +122,14 @@ describe('remember', () => {
 // ── Recall ──────────────────────────────────────────────────────────────
 
 describe('recall', () => {
-  beforeEach(() => {
-    handleTool('remember', {
+  beforeEach(async () => {
+    await handleTool('remember', {
       name: 'auth-pattern',
       type: 'pattern',
       observations: ['JWT tokens for stateless auth'],
       tags: ['project:myapp'],
     });
-    handleTool('remember', {
+    await handleTool('remember', {
       name: 'db-decision',
       type: 'decision',
       observations: ['Use PostgreSQL for persistence'],
@@ -137,15 +137,15 @@ describe('recall', () => {
     });
   });
 
-  it('finds entities by query', () => {
-    const result = handleTool('recall', { query: 'auth' });
+  it('finds entities by query', async () => {
+    const result = await handleTool('recall', { query: 'auth' });
     const data = JSON.parse(result.content[0].text);
     expect(data.length).toBeGreaterThanOrEqual(1);
     expect(data.some((e: any) => e.name === 'auth-pattern')).toBe(true);
   });
 
-  it('filters by tag', () => {
-    const result = handleTool('recall', {
+  it('filters by tag', async () => {
+    const result = await handleTool('recall', {
       query: 'auth',
       tag: 'project:myapp',
     });
@@ -154,32 +154,32 @@ describe('recall', () => {
     expect(data[0].name).toBe('auth-pattern');
   });
 
-  it('lists recent when no query provided', () => {
-    const result = handleTool('recall', {});
+  it('lists recent when no query provided', async () => {
+    const result = await handleTool('recall', {});
     const data = JSON.parse(result.content[0].text);
     expect(data.length).toBe(2);
   });
 
-  it('returns empty array when nothing matches', () => {
-    const result = handleTool('recall', { query: 'nonexistent-xyz-123' });
+  it('returns empty array when nothing matches', async () => {
+    const result = await handleTool('recall', { query: 'nonexistent-xyz-123' });
     const data = JSON.parse(result.content[0].text);
     expect(data).toEqual([]);
   });
 
-  it('respects limit parameter', () => {
-    const result = handleTool('recall', { limit: 1 });
+  it('respects limit parameter', async () => {
+    const result = await handleTool('recall', { limit: 1 });
     const data = JSON.parse(result.content[0].text);
     expect(data.length).toBe(1);
   });
 
-  it('rejects recall with limit=0', () => {
-    const result = handleTool('recall', { limit: 0 });
+  it('rejects recall with limit=0', async () => {
+    const result = await handleTool('recall', { limit: 0 });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('limit');
   });
 
-  it('rejects recall with limit=101', () => {
-    const result = handleTool('recall', { limit: 101 });
+  it('rejects recall with limit=101', async () => {
+    const result = await handleTool('recall', { limit: 101 });
     expect(result.isError).toBe(true);
   });
 });
@@ -187,51 +187,51 @@ describe('recall', () => {
 // ── Forget ──────────────────────────────────────────────────────────────
 
 describe('forget', () => {
-  it('archives an entity instead of deleting it', () => {
-    handleTool('remember', {
+  it('archives an entity instead of deleting it', async () => {
+    await handleTool('remember', {
       name: 'old-design', type: 'decision', observations: ['Use REST'],
     });
 
-    const result = handleTool('forget', { name: 'old-design' });
+    const result = await handleTool('forget', { name: 'old-design' });
     const data = JSON.parse(result.content[0].text);
     expect(data.archived).toBe(true);
     expect(data.name).toBe('old-design');
 
     // Hidden from normal recall
-    const recall = handleTool('recall', { query: 'REST' });
+    const recall = await handleTool('recall', { query: 'REST' });
     expect(JSON.parse(recall.content[0].text)).toEqual([]);
 
     // Visible with include_archived
-    const recallAll = handleTool('recall', { query: 'REST', include_archived: true });
+    const recallAll = await handleTool('recall', { query: 'REST', include_archived: true });
     const allData = JSON.parse(recallAll.content[0].text);
     expect(allData).toHaveLength(1);
     expect(allData[0].archived).toBe(true);
   });
 
-  it('removes a specific observation without archiving', () => {
-    handleTool('remember', {
+  it('removes a specific observation without archiving', async () => {
+    await handleTool('remember', {
       name: 'design', type: 'decision', observations: ['Use JWT', 'Use RS256'],
     });
 
-    const result = handleTool('forget', { name: 'design', observation: 'Use JWT' });
+    const result = await handleTool('forget', { name: 'design', observation: 'Use JWT' });
     const data = JSON.parse(result.content[0].text);
     expect(data.observation_removed).toBe(true);
     expect(data.remaining_observations).toBe(1);
 
     // Entity still active and searchable
-    const recall = handleTool('recall', { query: 'RS256' });
+    const recall = await handleTool('recall', { query: 'RS256' });
     expect(JSON.parse(recall.content[0].text)).toHaveLength(1);
   });
 
-  it('returns not-found for non-existent entity', () => {
-    const result = handleTool('forget', { name: 'ghost' });
+  it('returns not-found for non-existent entity', async () => {
+    const result = await handleTool('forget', { name: 'ghost' });
     const data = JSON.parse(result.content[0].text);
     expect(data.archived).toBe(false);
     expect(data.message).toContain('not found');
   });
 
-  it('rejects forget with empty name', () => {
-    const result = handleTool('forget', { name: '' });
+  it('rejects forget with empty name', async () => {
+    const result = await handleTool('forget', { name: '' });
     expect(result.isError).toBe(true);
   });
 });
@@ -239,8 +239,8 @@ describe('forget', () => {
 // ── Unknown tool ────────────────────────────────────────────────────────
 
 describe('unknown tool', () => {
-  it('returns error for unknown tool name', () => {
-    const result = handleTool('nonexistent', {});
+  it('returns error for unknown tool name', async () => {
+    const result = await handleTool('nonexistent', {});
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Unknown tool');
   });


### PR DESCRIPTION
## Summary

- **Multi-factor scoring**: entities ranked by relevance (0.35) + recency (0.25) + frequency (0.20) + confidence (0.15) + temporal validity (0.05)
- **LLM query expansion**: "login security" finds "OAuth PKCE" via Smart Mode (~97% R@5)
- **Access tracking**: recall auto-increments access_count and last_accessed_at
- **Conflict detection**: "contradicts" relations surface warnings in recall results
- **Temporal validity**: valid_from/valid_until on entities, expired facts rank lower
- **Pluggable LLM**: Anthropic, OpenAI, Ollama — auto-detected, graceful fallback

## Test plan
- [x] 224/224 tests pass (was 183)
- [x] typecheck clean
- [ ] CI matrix