### PR TITLE
fix: v3.0.1 — built-in skills, dashboard content fixes, Preact rebuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "files": [
     "dist/",
+    "dashboard/dist/",
     ".mcp.json",
     "hooks/hooks.json",
     "scripts/hooks/",
+    "skills/",
     "plugin.json",
     "README.md",
     "LICENSE"

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,19 @@
 {
   "name": "memesh",
   "description": "MeMesh — The lightest universal AI memory layer. One SQLite file, any LLM, zero cloud.",
-  "author": { "name": "PCIRCLE AI" },
-  "version": "3.0.0",
+  "author": {
+    "name": "PCIRCLE AI"
+  },
+  "version": "3.0.1",
   "homepage": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",
-  "keywords": ["claude-code", "mcp", "knowledge-graph", "ai-memory"],
+  "keywords": [
+    "claude-code",
+    "mcp",
+    "knowledge-graph",
+    "ai-memory"
+  ],
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills"

--- a/plugin.json
+++ b/plugin.json
@@ -8,5 +8,6 @@
   "license": "MIT",
   "keywords": ["claude-code", "mcp", "knowledge-graph", "ai-memory"],
   "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/hooks.json"
+  "hooks": "./hooks/hooks.json",
+  "skills": "./skills"
 }

--- a/skills/memesh-review/SKILL.md
+++ b/skills/memesh-review/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: memesh-review
+description: Review and clean up the MeMesh memory database. Find stale, contradicting, or redundant memories and suggest cleanup actions. Use when asked to "review memories", "clean up knowledge", or "what's in my memory".
+user-invocable: true
+---
+
+# MeMesh Memory Review
+
+Review the memory database and provide actionable cleanup recommendations.
+
+## Process
+
+1. **Recall recent memories** — use `recall` with no query to see what's stored
+2. **Check for staleness** — identify memories not accessed in 30+ days
+3. **Check for conflicts** — look for `contradicts` relations or opposing observations
+4. **Check for verbosity** — entities with 5+ observations that could be consolidated
+5. **Report findings** with specific actions
+
+## Steps
+
+### Step 1: Load overview
+```json
+recall: {"limit": 50}
+```
+
+### Step 2: Analyze and report
+
+Present findings in this format:
+
+```
+## Memory Review
+
+### Summary
+- Total memories recalled: N
+- Active: N | Archived: N
+
+### Stale (not accessed in 30+ days)
+- "entity-name" — last observation: "..." — Suggest: archive or keep?
+
+### Could be consolidated (5+ observations)
+- "entity-name" (8 observations) — Suggest: run consolidate
+
+### Potential conflicts
+- "use-jwt" vs "no-jwt" — contradicting auth decisions
+
+### Recommended actions
+1. Archive "old-design" (superseded by "new-design")
+2. Consolidate "auth-history" (12 observations → ~3)
+3. Review conflict between "X" and "Y"
+```
+
+### Step 3: Execute approved actions
+
+After presenting the report, ask the user which actions to execute. Then use `forget`, `consolidate`, or `remember` with `supersedes` accordingly.

--- a/skills/memesh/SKILL.md
+++ b/skills/memesh/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: memesh
+description: Use MeMesh to remember, recall, and manage AI knowledge across sessions. Triggers when the user asks to remember something, recall past decisions, forget outdated info, or manage their memory. Also triggers proactively when you make important decisions, fix bugs, or learn lessons worth preserving.
+user-invocable: true
+---
+
+# MeMesh — AI Memory Management
+
+You have access to MeMesh, a persistent memory layer with 6 tools. Use them to remember important knowledge across sessions.
+
+## When to Use (Proactive)
+
+**Remember automatically when:**
+- A design decision is made ("let's use OAuth" → remember it)
+- A bug is fixed (root cause + fix → remember as lesson)
+- A pattern is established ("we always use Zod for validation" → remember as pattern)
+- Architecture changes ("moved from monolith to microservices" → remember)
+- The user explicitly says "remember this" or "don't forget"
+
+**Recall automatically when:**
+- Starting work on a feature that might have prior decisions
+- The user asks "what did we decide about X?"
+- You need context about a project's conventions
+
+**Forget when:**
+- A decision is superseded by a new one (use `supersedes` relation)
+- The user says "forget about X" or "that's outdated"
+
+## Tools Reference
+
+### remember
+```json
+{
+  "name": "auth-decision",
+  "type": "decision",
+  "observations": ["Use OAuth 2.0 with PKCE for authentication"],
+  "tags": ["project:myapp", "topic:auth"],
+  "relations": [{"to": "old-auth", "type": "supersedes"}]
+}
+```
+Types: `decision`, `pattern`, `lesson`, `bug_fix`, `architecture`, `convention`
+
+### recall
+```json
+{"query": "authentication", "tag": "project:myapp", "limit": 10}
+```
+Omit query to list recent memories. Results are ranked by relevance, recency, and access frequency.
+
+### forget
+```json
+{"name": "outdated-design"}
+```
+Archives the entity (soft-delete). Add `"observation": "specific text"` to remove just one fact.
+
+### consolidate
+```json
+{"name": "auth-history", "min_observations": 5}
+```
+Compresses verbose memories using LLM. Requires Smart Mode configured.
+
+### export / import
+```json
+{"tag": "project:myapp"}
+```
+Export memories as JSON for sharing. Import with merge strategies: `skip`, `overwrite`, `append`.
+
+## Best Practices
+
+1. **Be specific** — "Use OAuth 2.0 with PKCE" not "auth stuff decided"
+2. **Tag by project** — Always include `project:<name>` tag
+3. **Use relations** — Link related decisions with `related-to`, replace old ones with `supersedes`
+4. **Type correctly** — Use the right type (decision/pattern/lesson) for better search
+5. **Don't over-remember** — Skip trivial things. Remember decisions that took > 5 minutes to make.


### PR DESCRIPTION
## v3.0.1 Patch

- Built-in skills: `/memesh` and `/memesh-review` for Claude Code plugin
- Dashboard rebuilt with Preact + Vite (proper component architecture)
- Content quality: filter system tags, pagination, meaningful labels
- README marketing redesign with dashboard screenshots
- Dashboard includes `dashboard/dist/` and `skills/` in npm package

## Test plan
- [x] 289/289 tests
- [x] Fresh clean build
- [x] Smoke test pass