### PR TITLE
Prepare v4.0.4 release metadata and notes

### DIFF
--- a/CHANGELOG-4.0.4.md
+++ b/CHANGELOG-4.0.4.md
@@ -1,0 +1,38 @@
+# MeMesh v4.0.4 — Doctor Diagnostics & Release Prep
+
+**Release Date:** 2026-04-25  
+**Type:** Patch release candidate after v4.0.3
+
+---
+
+## Summary
+
+v4.0.4 packages the activation-and-trust follow-up work around `memesh doctor`, release-facing install diagnostics, and the supporting packaging/doc cleanup needed to make those checks trustworthy.
+
+## Added
+
+- **CLI `memesh doctor`:** new local diagnostics command that verifies install method, DB access, config readability, `.mcp.json`, hook config, shipped hook scripts, dashboard artifact presence, runtime capabilities, cached update state, and optional HTTP reachability.
+- **Machine-readable doctor output:** `memesh doctor --json` returns per-check results and overall status for support automation and scripted verification.
+- **Focused doctor regression coverage:** added tests for healthy installs, invalid MCP config, missing hook scripts, and first-run warning states.
+
+## Improved
+
+- **Troubleshooting path:** README and platform troubleshooting now tell users to run `memesh doctor` for end-to-end local verification.
+- **CLI messaging consistency:** the top-level CLI description now matches the local coding-agent positioning used elsewhere in the package.
+- **Hook packaging correctness:** `pre-edit-recall.js` now ships executable, and the build step applies executable bits consistently to all shipped hook scripts.
+- **Database failure clarity:** doctor now surfaces the real DB open failure message instead of hiding it behind a generic error.
+
+## Documentation
+
+- `CHANGELOG.md` now includes the v4.0.4 batch.
+- Package, plugin, and dashboard metadata now align on `4.0.4`.
+- README test count now reflects the current full-suite result of 489 tests.
+
+## Verification
+
+- `npm run typecheck` — passed.
+- `npm test -- --run` — 34 files, 489 tests passed.
+- `npm run build` — passed.
+- `npm run test:packaged` — passed.
+- `npm run test:e2e-dashboard` — passed.
+- `npm publish --dry-run --access public` — planned as final pre-release gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.0.4] — 2026-04-25
+
+### Added
+- **CLI `memesh doctor` diagnostics** — Added a release-focused local health check that verifies install method, database access, config readability, `.mcp.json`, `hooks/hooks.json`, hook script presence/executable bits, dashboard artifact availability, current capabilities, cached update status, and optional local HTTP reachability.
+- **Doctor JSON contract** — `memesh doctor --json` now exposes machine-readable diagnostics and per-check status for support, automation, and onboarding verification.
+- **Doctor regression coverage** — Added focused tests for healthy source-checkout installs, invalid MCP config, missing hook scripts, and first-run warning states.
+
+### Improved
+- **Actionable install troubleshooting** — README and platform troubleshooting now point users to `memesh doctor` for end-to-end local verification instead of relying only on `memesh status`.
+- **CLI positioning consistency** — The `memesh` CLI banner now matches the current product wedge: local memory for Claude Code and MCP coding agents.
+- **Hook script packaging hygiene** — `pre-edit-recall.js` now ships with the correct executable bit, and the build step applies executable bits consistently across all shipped hook scripts.
+- **Database failure transparency** — `memesh doctor` now surfaces the actual database-open error message instead of hiding it behind a generic failure line.
+
+### Changed
+- Package, plugin, and dashboard metadata now target `4.0.4`.
+- 489 tests passing across 34 test files.
+
 ## [4.0.3] — 2026-04-25
 
 ### Improved

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memesh-dashboard",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memesh-dashboard",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dependencies": {
         "preact": "^10.25.0"
       },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memesh-dashboard",
   "private": true,
-  "version": "4.0.3",
+  "version": "4.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.0.3
+**Version**: 4.0.4
 
 ---
 
@@ -180,7 +180,7 @@ The primary dashboard is now the packaged Preact single-page app served by `GET 
 - preferred over the legacy HTML generator path
 - used for live local inspection and settings/config flows
 
-**Dashboard tabs (v4.0.3)**:
+**Dashboard tabs (v4.0.4)**:
 
 | Tab | Feature |
 |-----|---------|

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.0.3
+**Version**: 4.0.4
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---
@@ -480,8 +480,8 @@ Use `?cached=1` to read the cached state only. Without it, MeMesh prefers a fres
 {
   "success": true,
   "data": {
-    "currentVersion": "4.0.3",
-    "latestVersion": "4.0.3",
+    "currentVersion": "4.0.4",
+    "latestVersion": "4.0.4",
     "checkedAt": "2026-04-24T10:15:00.000Z",
     "lastAttemptAt": "2026-04-24T10:15:00.000Z",
     "lastSuccessfulCheckAt": "2026-04-24T10:00:00.000Z",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.0.3",
+  "version": "4.0.4",
   "homepage": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -205,11 +205,15 @@ describe('HTTP Transport: GET /v1/config', () => {
 
 describe('HTTP Transport: GET /v1/update-status', () => {
   it('returns cached update metadata when requested', async () => {
+    const now = Date.now();
+    const lastSuccessfulCheckAt = new Date(now - 60 * 60 * 1000).toISOString();
+    const lastAttemptAt = new Date(now - 45 * 60 * 1000).toISOString();
+
     fs.writeFileSync(updateCheckPath, JSON.stringify({
       currentVersion: '4.0.1',
-      latestVersion: '4.0.4',
-      lastAttemptAt: '2026-04-24T10:15:00.000Z',
-      lastSuccessfulCheckAt: '2026-04-24T10:00:00.000Z',
+      latestVersion: '9.9.9',
+      lastAttemptAt,
+      lastSuccessfulCheckAt,
       lastError: 'npm unavailable',
       checkSucceeded: false,
     }));
@@ -218,13 +222,13 @@ describe('HTTP Transport: GET /v1/update-status', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data.currentVersion).toBeDefined();
-    expect(res.body.data.latestVersion).toBe('4.0.4');
+    expect(res.body.data.latestVersion).toBe('9.9.9');
     expect(res.body.data.updateAvailable).toBe(true);
     expect(res.body.data.checkSucceeded).toBe(false);
     expect(res.body.data.source).toBe('cache');
-    expect(res.body.data.checkedAt).toBe('2026-04-24T10:15:00.000Z');
-    expect(res.body.data.lastAttemptAt).toBe('2026-04-24T10:15:00.000Z');
-    expect(res.body.data.lastSuccessfulCheckAt).toBe('2026-04-24T10:00:00.000Z');
+    expect(res.body.data.checkedAt).toBe(lastAttemptAt);
+    expect(res.body.data.lastAttemptAt).toBe(lastAttemptAt);
+    expect(res.body.data.lastSuccessfulCheckAt).toBe(lastSuccessfulCheckAt);
     expect(res.body.data.lastError).toBe('npm unavailable');
     expect(res.body.data.freshness).toBe('cached');
     expect(res.body.data.installChannel).toBe('source-checkout');

--- a/tests/version-check.test.ts
+++ b/tests/version-check.test.ts
@@ -69,7 +69,10 @@ describe('version check', () => {
       freshness: 'fresh',
     });
 
-    const cached = getLastUpdateCheck('4.0.2', { updateCheckPath });
+    const cached = getLastUpdateCheck('4.0.2', {
+      updateCheckPath,
+      now: new Date('2026-04-24T10:30:00.000Z'),
+    });
     expect(cached).toEqual({
       currentVersion: '4.0.2',
       latestVersion: '4.0.3',
@@ -110,7 +113,10 @@ describe('version check', () => {
       freshness: 'cached',
     });
 
-    const cached = getLastUpdateCheck('4.0.2', { updateCheckPath });
+    const cached = getLastUpdateCheck('4.0.2', {
+      updateCheckPath,
+      now: new Date('2026-04-24T11:30:00.000Z'),
+    });
     expect(cached).toEqual({
       currentVersion: '4.0.2',
       latestVersion: '4.0.3',
@@ -161,7 +167,10 @@ describe('version check', () => {
       checkSucceeded: true,
     }));
 
-    const cached = getLastUpdateCheck('4.0.2', { updateCheckPath });
+    const cached = getLastUpdateCheck('4.0.2', {
+      updateCheckPath,
+      now: new Date('2026-04-24T10:30:00.000Z'),
+    });
     expect(cached).toEqual({
       currentVersion: '4.0.2',
       latestVersion: '4.0.2',


### PR DESCRIPTION
## Summary
- bump package, plugin, and dashboard metadata from `4.0.3` to `4.0.4`
- add `CHANGELOG-4.0.4.md` and update `CHANGELOG.md`
- sync version markers in API and architecture docs
- make release-gate tests deterministic for version/freshness-sensitive checks

## Verification
- `npm run typecheck`
- `npm test -- --run`
- `npm run build`
- `npm run test:packaged`
- `npm run test:e2e-dashboard`
- `npm publish --dry-run --access public`

## Notes
- this PR prepares release metadata and release notes only
- the `memesh doctor` feature work is already on `main`; this PR carries the `4.0.4` release-prep commit for that batch