### PR TITLE
feat(plugin): repackage as .claude-plugin/ for marketplace install

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.1.4",
+  "version": "4.1.5",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",
@@ -13,8 +13,5 @@
     "mcp",
     "knowledge-graph",
     "ai-memory"
-  ],
-  "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/hooks.json",
-  "skills": "./skills"
+  ]
 }

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@
 /.github/CODEOWNERS        @PCIRCLE-AI/maintainers
 
 # Plugin manifest — wired up by Claude Code on install
-/plugin.json               @PCIRCLE-AI/maintainers
+/.claude-plugin/plugin.json               @PCIRCLE-AI/maintainers
 /.mcp.json                 @PCIRCLE-AI/maintainers
 
 # Manifest of shipped artefacts (skills, hooks) — generated at build

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@ secrets/
 # === Claude Code local config ===
 CLAUDE.md
 .claude/
+# Note: .claude-plugin/plugin.json IS the Claude Code plugin manifest for
+# memesh itself — it MUST be committed. Local-dev installs of OTHER
+# plugins land under .claude-plugin/<plugin-name>/ and stay ignored.
 .claude-plugin/marketplace.json
-.claude-plugin/plugin.json
-.claude-plugin/memesh/
+.claude-plugin/*/
 
 # === OS files ===
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.1.5] — 2026-05-09
+
+Structural repackaging for Claude Code's plugin marketplace. No behavioural changes for existing users.
+
+### Changed
+- **Plugin manifest moved** to `.claude-plugin/plugin.json` from `plugin.json` (root). This is the canonical location Claude Code's plugin spec expects, and the prerequisite for shipping memesh on the plugin marketplace. The manifest itself is now minimal — `mcpServers`, `hooks`, and `skills` references were removed because Claude Code auto-discovers them from default locations (`.mcp.json`, `hooks/hooks.json`, `skills/`). Path references updated in 3 build/test scripts and 3 docs files.
+- **`.gitignore`** narrowed: previously `.claude-plugin/plugin.json` was ignored (a leftover rule from when `.claude-plugin/` only meant local-dev plugin installs). The pattern now ignores `.claude-plugin/<other-plugin>/` subdirectories while keeping memesh's own manifest tracked.
+
+### Backward compatibility
+- `npm install -g @pcircle/memesh` users: unaffected. CLI binaries unchanged.
+- `memesh install-hooks` users: unaffected. Hook wiring path unchanged.
+
+### Notes
+- A `.claude-plugin/marketplace.json` companion (so users can `claude plugin marketplace add PCIRCLE-AI/memesh-llm-memory`) is a deliberate follow-up, not part of this release.
+
 ## [4.1.4] — 2026-05-08
 
 Major release consolidating dashboard v2 + v3, the auto-update loop, the new `install-hooks` command, and an LLM-driven memory consolidation system.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Documentation is part of the change, not follow-up work.
 - Update `README.md` when behavior, installation, or development workflow changes.
 - Update `docs/api/API_REFERENCE.md` when MCP tool signatures, parameters, or responses change.
 - Update `docs/ARCHITECTURE.md` when module structure, storage behavior, or packaging flow changes.
-- Keep `package.json`, `package-lock.json`, and `plugin.json` version metadata aligned.
+- Keep `package.json`, `package-lock.json`, and `.claude-plugin/plugin.json` version metadata aligned.
 
 The repository-level engineering rules in `CLAUDE.md` apply to contributor changes as well.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.1.4
+**Version**: 4.1.5
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,7 +344,7 @@ MeMesh works with any MCP-compatible client:
 
 | Client | Integration Method |
 |--------|-------------------|
-| Claude Code | Plugin (native, via plugin.json + hooks) |
+| Claude Code | Plugin (native, via `.claude-plugin/plugin.json` + hooks) |
 | Claude Managed Agents | MCP connector (beta, via session config) |
 | Claude Desktop | MCP server config |
 | Custom apps | Direct stdio MCP connection |

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.1.4
+**Version**: 4.1.5
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",
@@ -17,7 +17,7 @@
     "hooks/hooks.json",
     "scripts/hooks/",
     "skills/",
-    "plugin.json",
+    ".claude-plugin/",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/generate-skills-manifest.mjs
+++ b/scripts/generate-skills-manifest.mjs
@@ -63,7 +63,7 @@ targets.push(...await walk(join(repoRoot, 'skills')));
 targets.push(...(await walk(join(repoRoot, 'scripts', 'hooks'))).filter(p => p.endsWith('.js')));
 
 // Single-file artefacts (declarative wiring read by Claude Code itself)
-for (const f of ['hooks/hooks.json', '.mcp.json', 'plugin.json']) {
+for (const f of ['hooks/hooks.json', '.mcp.json', '.claude-plugin/plugin.json']) {
   const full = join(repoRoot, f);
   try { statSync(full); targets.push(full); } catch { /* missing — skip */ }
 }

--- a/scripts/generate-skills-manifest.mjs
+++ b/scripts/generate-skills-manifest.mjs
@@ -17,7 +17,7 @@
 //   - skills/**/SKILL.md           (loaded as Claude system prompt)
 //   - scripts/hooks/*.js           (run in user's Claude Code process)
 //   - hooks/hooks.json             (declares which hooks are active)
-//   - .mcp.json, plugin.json       (Claude Code wiring)
+//   - .mcp.json, .claude-plugin/plugin.json  (Claude Code wiring)
 //
 // What's NOT covered (out of scope for this manifest):
 //   - dist/**/*.js — Node code path. Tampering there is detected by

--- a/scripts/hooks/_shared.js
+++ b/scripts/hooks/_shared.js
@@ -444,10 +444,10 @@ export function tryAcquireAutoUpdateLock(version) {
     // our token won. If a concurrent caller's rename landed in the
     // window between our rename and our read, their token is now there
     // and we correctly conclude we did NOT acquire the lock. That race
-    // outcome IS the contract — CodeQL flags it as TOCTOU but it is the
-    // standard last-writer-wins lock-file pattern.
-    // codeql[js/file-system-race]: justified — the read is the lock
-    // verification step, not a post-check before mutation.
+    // outcome IS the contract — last-writer-wins lock-file pattern, not
+    // a TOCTOU defect. (CodeQL js/file-system-race #82 is dismissed on
+    // the security dashboard with this rationale; CodeQL does not honor
+    // inline suppression comments, so dismissal is the correct route.)
     let recorded;
     try { recorded = fs.readFileSync(lockPath, 'utf8'); } catch { return { acquired: false, lockPath }; }
     return recorded.split('\n')[0] === myToken

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -56,7 +56,7 @@ const packageDir = path.join(extractDir, 'package');
 const requiredFiles = [
   // Core
   'package.json',
-  'plugin.json',
+  '.claude-plugin/plugin.json',
   '.mcp.json',
   'hooks/hooks.json',
   // Dist — core engine

--- a/src/core/install-hooks.ts
+++ b/src/core/install-hooks.ts
@@ -4,8 +4,9 @@
 //
 // PROBLEM
 // ───────
-// memesh ships `plugin.json` + `hooks/hooks.json` so it can run as a
-// Claude Code plugin. But `npm install -g @pcircle/memesh` only puts
+// memesh ships `.claude-plugin/plugin.json` + `hooks/hooks.json` so it
+// can run as a Claude Code plugin. But `npm install -g @pcircle/memesh`
+// only puts
 // the CLI binary on PATH — Claude Code's plugin runtime never reads
 // memesh's hooks.json. Result: memesh's auto-capture (session-summary,
 // pre-edit-recall, pre-bash-orchestration-nudge, etc.) silently does

--- a/tests/installation.test.ts
+++ b/tests/installation.test.ts
@@ -17,9 +17,9 @@ describe('Installation Verification', () => {
       expect(pkg.name).toBe('@pcircle/memesh');
     });
 
-    it('should have plugin.json with matching version', () => {
+    it('should have .claude-plugin/plugin.json with matching version', () => {
       const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-      const plugin = JSON.parse(fs.readFileSync('plugin.json', 'utf8'));
+      const plugin = JSON.parse(fs.readFileSync('.claude-plugin/plugin.json', 'utf8'));
       expect(plugin.version).toBe(pkg.version);
     });
 
@@ -71,9 +71,14 @@ describe('Installation Verification', () => {
       }
     });
 
-    it('should have plugin.json with skills reference', () => {
-      const plugin = JSON.parse(fs.readFileSync('plugin.json', 'utf8'));
-      expect(plugin.skills).toBeDefined();
+    it('ships skills via the default-discovery `skills/` directory', () => {
+      // The new Claude Code plugin schema auto-discovers components from
+      // default locations; explicit refs in plugin.json are only needed
+      // for non-default paths. So this asserts the directory itself
+      // exists rather than checking plugin.json for an explicit `skills`
+      // field (which we deliberately omit so the manifest stays minimal).
+      expect(fs.existsSync('skills')).toBe(true);
+      expect(fs.statSync('skills').isDirectory()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Moves memesh's plugin manifest from `plugin.json` (root) to
`.claude-plugin/plugin.json` (the canonical location Claude Code's
plugin spec expects). Structural prerequisite for shipping on the
Claude Code plugin marketplace.

After this change, install path will become:

```
/plugin marketplace add PCIRCLE-AI/memesh-llm-memory
/plugin install memesh@PCIRCLE-AI
```

vs. today's `npm install -g @pcircle/memesh && memesh install-hooks`.

## What's in this PR

- `plugin.json` → `.claude-plugin/plugin.json` (with stripped redundant
  fields — Claude Code auto-discovers `skills/`, `hooks/hooks.json`,
  `.mcp.json` from default locations)
- `package.json` `files` array updated; version bumped 4.1.4 → 4.1.5
- Path references updated in 3 scripts + 1 test + 3 doc files
- `.gitignore` fix: previous rule was un-tracking the very manifest we
  just moved. Replaced with narrower pattern that keeps our manifest
  but ignores `.claude-plugin/<other-plugin>/` local installs.

## What's NOT in this PR (deliberately deferred)

- `.claude-plugin/marketplace.json` (Phase 2)
- Skills migration (the `memesh-remember` / `memesh-recall` skill
  pattern discussed in earlier design notes)
- Submission to Anthropic's official plugin marketplace

## Backward compatibility

- `npm install -g` users: unaffected. CLI binaries still on PATH.
- `memesh install-hooks` users: unaffected. Hook wiring path unchanged.
- Going forward: users can also install via Claude Code's
  `/plugin install` once the marketplace.json companion ships.

## Test plan

- [x] `npm run build` smoke 6/6 pass
- [x] `tests/installation.test.ts` + `tests/core/install-hooks.test.ts` 26/26 pass
- [ ] CI all green (this PR)
- [ ] Release-verify gate green (this PR)

## Notes

- Two release-verify checks failed locally due to local-state drift on
  my dev machine, unrelated to this repackage. CI fresh runners should
  not see them.