### PR TITLE
feat(plugin): marketplace.json — one-line install via Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "memesh",
-      "source": ".",
+      "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
       "version": "4.1.6",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "pcircle-ai",
+  "owner": {
+    "name": "PCIRCLE AI"
+  },
+  "plugins": [
+    {
+      "name": "memesh",
+      "source": ".",
+      "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
+      "version": "4.1.6",
+      "author": {
+        "name": "PCIRCLE AI"
+      },
+      "homepage": "https://pcircle.ai/memesh-llm-memory",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "mcp",
+        "knowledge-graph",
+        "ai-memory"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.1.5",
+  "version": "4.1.6",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,10 @@ secrets/
 # === Claude Code local config ===
 CLAUDE.md
 .claude/
-# Note: .claude-plugin/plugin.json IS the Claude Code plugin manifest for
-# memesh itself — it MUST be committed. Local-dev installs of OTHER
-# plugins land under .claude-plugin/<plugin-name>/ and stay ignored.
-.claude-plugin/marketplace.json
+# Note: .claude-plugin/plugin.json AND .claude-plugin/marketplace.json
+# ARE Claude Code plugin/marketplace manifests for memesh itself — both
+# MUST be committed. Local-dev installs of OTHER plugins land under
+# .claude-plugin/<plugin-name>/ and stay ignored.
 .claude-plugin/*/
 
 # === OS files ===

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "memesh": {
-      "command": "memesh-mcp"
+      "command": "npx",
+      "args": ["-y", "-p", "@pcircle/memesh", "memesh-mcp"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.1.6] — 2026-05-09
+
+Marketplace manifest — memesh is now installable as a Claude Code plugin in one step.
+
+### Added
+- **`.claude-plugin/marketplace.json`** companion to the plugin manifest. With this file, the repo doubles as its own one-plugin marketplace. Users can now install with:
+  ```
+  /plugin marketplace add PCIRCLE-AI/memesh-llm-memory
+  /plugin install memesh@pcircle-ai
+  ```
+  vs. the previous flow of `npm install -g @pcircle/memesh && memesh install-hooks`. The npm path still works and is preserved verbatim — this is an additional install route, not a replacement.
+- **`.gitignore`** further narrowed: previously `.claude-plugin/marketplace.json` was ignored alongside `.claude-plugin/plugin.json`. Now only `.claude-plugin/<other-plugin>/` subdirectories are ignored (where local-dev plugin installs land).
+
+### Backward compatibility
+- Same as v4.1.5: `npm install -g` users + `memesh install-hooks` users see no behaviour change.
+
 ## [4.1.5] — 2026-05-09
 
 Structural repackaging for Claude Code's plugin marketplace. No behavioural changes for existing users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,23 @@ All notable changes to MeMesh are documented here.
 
 ## [4.1.6] — 2026-05-09
 
-Marketplace manifest — memesh is now installable as a Claude Code plugin in one step.
+Marketplace manifest — memesh is installable as a Claude Code plugin in one step. Two install routes (plugin and npm) are now positioned as complementary, not exclusive.
 
 ### Added
-- **`.claude-plugin/marketplace.json`** companion to the plugin manifest. With this file, the repo doubles as its own one-plugin marketplace. Users can now install with:
+- **`.claude-plugin/marketplace.json`** companion to the plugin manifest. With this file, the repo doubles as its own one-plugin marketplace. Users can install with:
   ```
   /plugin marketplace add PCIRCLE-AI/memesh-llm-memory
   /plugin install memesh@pcircle-ai
   ```
-  vs. the previous flow of `npm install -g @pcircle/memesh && memesh install-hooks`. The npm path still works and is preserved verbatim — this is an additional install route, not a replacement.
+  alongside the existing `npm install -g @pcircle/memesh && memesh install-hooks` flow. The npm path is preserved verbatim — this is an additional install route, not a replacement.
 - **`.gitignore`** further narrowed: previously `.claude-plugin/marketplace.json` was ignored alongside `.claude-plugin/plugin.json`. Now only `.claude-plugin/<other-plugin>/` subdirectories are ignored (where local-dev plugin installs land).
+
+### Documentation
+- **README Get Started** rewritten to describe the two install routes as **complementary**, not exclusive. The plugin (Option A) gives in-session auto-capture, recall, and the `/memesh` skill. The npm install (Option B) gives the standalone toolkit: `memesh` CLI, dashboard launcher, `memesh doctor`, and the `memesh-mcp` stdio server for non-Claude-Code agents. The previous "ships together" wording overstated what a plugin-only install provides.
+- **Step 2 / Step 3** examples are clarified as Option B CLI flows, with a one-line note that Option A users do the same operations through the Claude Code conversation.
+
+### Fixed
+- **`marketplace.json` `source` field** changed from `"."` to `"./"` to match the [Claude Code marketplace spec](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths) ("Must start with `./`"). Behaviour is unchanged in practice — both forms resolve to the marketplace root — but only `"./"` is spec-compliant.
 
 ### Backward compatibility
 - Same as v4.1.5: `npm install -g` users + `memesh install-hooks` users see no behaviour change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to MeMesh are documented here.
 
 ## [4.1.6] — 2026-05-09
 
-Marketplace manifest — memesh is installable as a Claude Code plugin in one step. Two install routes (plugin and npm) are now positioned as complementary, not exclusive.
+Marketplace manifest + plugin-context MCP wiring. The Claude Code plugin install (Option A) now delivers the full memesh experience — hooks, skills, MCP tools, CLI, and dashboard — without requiring a separate `npm install -g`. Aligns memesh with the canonical pattern used by Anthropic's official MCP plugins (e.g. `context7`).
 
 ### Added
 - **`.claude-plugin/marketplace.json`** companion to the plugin manifest. With this file, the repo doubles as its own one-plugin marketplace. Users can install with:
@@ -15,15 +15,23 @@ Marketplace manifest — memesh is installable as a Claude Code plugin in one st
   alongside the existing `npm install -g @pcircle/memesh && memesh install-hooks` flow. The npm path is preserved verbatim — this is an additional install route, not a replacement.
 - **`.gitignore`** further narrowed: previously `.claude-plugin/marketplace.json` was ignored alongside `.claude-plugin/plugin.json`. Now only `.claude-plugin/<other-plugin>/` subdirectories are ignored (where local-dev plugin installs land).
 
-### Documentation
-- **README Get Started** rewritten to describe the two install routes as **complementary**, not exclusive. The plugin (Option A) gives in-session auto-capture, recall, and the `/memesh` skill. The npm install (Option B) gives the standalone toolkit: `memesh` CLI, dashboard launcher, `memesh doctor`, and the `memesh-mcp` stdio server for non-Claude-Code agents. The previous "ships together" wording overstated what a plugin-only install provides.
-- **Step 2 / Step 3** examples are clarified as Option B CLI flows, with a one-line note that Option A users do the same operations through the Claude Code conversation.
-
 ### Fixed
+- **`.mcp.json` rewritten to the canonical Claude Code MCP plugin pattern**: `command: "npx"`, `args: ["-y", "-p", "@pcircle/memesh", "memesh-mcp"]`. Previously `command: "memesh-mcp"` assumed the binary was on system PATH, which is only true after `npm install -g`. The new form works in all three contexts identically:
+  1. **Claude Code plugin install** (Option A) — `npx` fetches `@pcircle/memesh` from the npm registry on first launch and caches it; subsequent launches are instant. No `dist/` build step or `prepare` script needed in the plugin install flow.
+  2. **npm global install** (Option B) — `npx` finds the already-installed `memesh-mcp` on `PATH` immediately, no network round-trip.
+  3. **Dev clone with `npm install`** — `npx` finds the locally installed `@pcircle/memesh`.
+
+  This pattern is what Anthropic's own `context7` plugin uses (`npx -y @upstash/context7-mcp`) and is now the standard for stdio-based MCP plugins. Plugin-only users (Option A) get a fully functional MCP server with no extra steps.
 - **`marketplace.json` `source` field** changed from `"."` to `"./"` to match the [Claude Code marketplace spec](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths) ("Must start with `./`"). Behaviour is unchanged in practice — both forms resolve to the marketplace root — but only `"./"` is spec-compliant.
 
+### Documentation
+- **README Get Started** rewritten so Option A is no longer a watered-down install. The plugin install gives hooks, skills, MCP tools, *and* full CLI / dashboard access — the latter via `npx @pcircle/memesh <command>` from any shell, with no `npm install -g` required. Option B (`npm install -g`) is now framed as an *optional optimisation*: it puts the `memesh` binary directly on `PATH` (skipping the per-call `npx` lookup) and exposes `memesh-mcp` as a fixed-path command for non-Claude-Code MCP clients (Cursor, Cline, etc.).
+- **Step 2 / Step 3** examples updated: the bash examples assume Option B; Option A users replace `memesh` with `npx @pcircle/memesh` (same flags, no install) or use the `/memesh` skill / MCP tools inside the Claude Code conversation.
+
 ### Backward compatibility
-- Same as v4.1.5: `npm install -g` users + `memesh install-hooks` users see no behaviour change.
+- `npm install -g @pcircle/memesh` users: the `memesh-mcp` binary is unchanged; behaviour is identical.
+- `memesh install-hooks` users: hook entries are unchanged.
+- Existing `~/.memesh/knowledge-graph.db`: untouched.
 
 ## [4.1.5] — 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ If you use Claude Code, install MeMesh as a plugin from inside the CLI:
 /plugin install memesh@pcircle-ai
 ```
 
-Claude Code wires the plugin's hooks and skills automatically — no `install-hooks` step needed. You get in-session auto-capture, proactive recall, and the `/memesh` skill (remember / recall / learn / forget) right in the Claude Code conversation. **For the standalone toolkit — `memesh` CLI on your shell, the dashboard, `memesh doctor`, or the `memesh-mcp` stdio server for non-Claude-Code agents — also install Option B below. The two paths are complementary.**
+Claude Code wires hooks, skills, and the MCP server automatically. You get in-session auto-capture, proactive recall, the `/memesh` skill (remember / recall / learn / forget) inside the Claude Code conversation, and `remember` / `recall` / `forget` / `learn` available as MCP tools to the agent. The CLI and the local dashboard are also fully accessible without any extra global install — `npx @pcircle/memesh <command>` runs every CLI command, and `npx @pcircle/memesh` launches the dashboard at `localhost:3737`. The MCP server uses the same `npx`-based launch pattern as Anthropic's official plugins (e.g. `context7`), so no `npm install -g` is needed for any feature.
 
-### Option B — npm global (works anywhere Node runs)
+### Option B — npm global (optional optimisation)
 
-For the full standalone toolkit (`memesh` CLI, dashboard launcher at `localhost:3737`, `memesh doctor`, `memesh-mcp` for Cursor / other MCP clients / terminal-only flows):
+If you want the binary directly on your shell `PATH` (so plain `memesh`, `memesh-mcp`, etc. work in any terminal without the per-call `npx` lookup), or you want to expose `memesh-mcp` as a fixed-path stdio command to **non-Claude-Code MCP clients** (Cursor, Cline, terminal-only flows):
 
 ```bash
 npm install -g @pcircle/memesh
@@ -82,7 +82,7 @@ The hooks coexist with any custom hooks you already have under `~/.claude/hooks/
 
 ### Step 2: Store a decision
 
-> The bash examples in Step 2 / Step 3 use the `memesh` CLI from **Option B**. Option A (plugin-only) users do the same through Claude Code conversation — the `/memesh` skill and the plugin's hooks cover identical flows; remember / recall / learn / forget all work inside the Claude Code session without leaving it.
+> The bash examples below assume `memesh` is on your `PATH` (Option B). Option A (plugin-only) users have two equivalent paths: ask in the Claude Code conversation (the `/memesh` skill + MCP tools cover the same flows), or replace `memesh` with `npx @pcircle/memesh` in any shell — same flags, no global install needed.
 
 ```bash
 memesh remember "Use OAuth 2.0 with PKCE for the new auth"

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ If you use Claude Code, install MeMesh as a plugin from inside the CLI:
 /plugin install memesh@pcircle-ai
 ```
 
-That's it. Hooks, MCP server, skills, and the dashboard ship together. No separate `install-hooks` step needed — Claude Code wires the plugin's hooks automatically.
+Claude Code wires the plugin's hooks and skills automatically — no `install-hooks` step needed. You get in-session auto-capture, proactive recall, and the `/memesh` skill (remember / recall / learn / forget) right in the Claude Code conversation. **For the standalone toolkit — `memesh` CLI on your shell, the dashboard, `memesh doctor`, or the `memesh-mcp` stdio server for non-Claude-Code agents — also install Option B below. The two paths are complementary.**
 
 ### Option B — npm global (works anywhere Node runs)
 
-If you want the CLI on your PATH outside Claude Code (Cursor, scripts, terminal-only flows), or you want fine-grained control over the install:
+For the full standalone toolkit (`memesh` CLI, dashboard launcher at `localhost:3737`, `memesh doctor`, `memesh-mcp` for Cursor / other MCP clients / terminal-only flows):
 
 ```bash
 npm install -g @pcircle/memesh
@@ -81,6 +81,8 @@ memesh doctor                # verifies "Hooks wired into Claude Code" passes
 The hooks coexist with any custom hooks you already have under `~/.claude/hooks/` — `install-hooks` writes additive entries and never overwrites yours. To remove later: `memesh uninstall-hooks`.
 
 ### Step 2: Store a decision
+
+> The bash examples in Step 2 / Step 3 use the `memesh` CLI from **Option B**. Option A (plugin-only) users do the same through Claude Code conversation — the `/memesh` skill and the plugin's hooks cover identical flows; remember / recall / learn / forget all work inside the Claude Code session without leaving it.
 
 ```bash
 memesh remember "Use OAuth 2.0 with PKCE for the new auth"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,20 @@ Reproduction commands, dataset SHA256, raw per-question results, and known-failu
 
 ## Get Started in 60 Seconds
 
-### Step 1: Install
+### Option A — Claude Code plugin (one-line install)
+
+If you use Claude Code, install MeMesh as a plugin from inside the CLI:
+
+```
+/plugin marketplace add PCIRCLE-AI/memesh-llm-memory
+/plugin install memesh@pcircle-ai
+```
+
+That's it. Hooks, MCP server, skills, and the dashboard ship together. No separate `install-hooks` step needed — Claude Code wires the plugin's hooks automatically.
+
+### Option B — npm global (works anywhere Node runs)
+
+If you want the CLI on your PATH outside Claude Code (Cursor, scripts, terminal-only flows), or you want fine-grained control over the install:
 
 ```bash
 npm install -g @pcircle/memesh
@@ -54,9 +67,11 @@ npm install -g @pcircle/memesh
 > - **Native modules** — `better-sqlite3` and `sqlite-vec` install via prebuilt binaries on macOS (arm64/x64), Linux (x64/arm64), and Windows x64. On uncommon platforms or when prebuilds fail, you'll need a working C/C++ toolchain.
 > - **Embedding model** — the first call that triggers a local embedding (e.g. `recall` with semantic mode) downloads `Xenova/all-MiniLM-L6-v2` (~80 MB) into `~/.memesh/models/`. Subsequent calls are instant. The default retrieval path (FTS5) does not require this download.
 
-### Step 1.5: Wire MeMesh into Claude Code (recommended, one-time)
+### Step 1.5: Wire MeMesh into Claude Code (npm path only)
 
-`npm install -g` puts the CLI on your PATH and registers the MCP server, but does **not** auto-wire MeMesh's Claude Code session hooks. Without these hooks, you can use `memesh remember` / `recall` manually but the **auto-capture loop** (sessions → lessons → recall on next session) is silent.
+If you installed via **Option A** (`/plugin install memesh@pcircle-ai`), skip this step — Claude Code wires plugin hooks automatically.
+
+If you installed via **Option B** (`npm install -g`), the CLI is on your PATH and the MCP server is registered, but the Claude Code session hooks are not auto-wired. Without them you can still use `memesh remember` / `recall` manually, but the **auto-capture loop** (sessions → lessons → recall on next session) is silent.
 
 ```bash
 memesh install-hooks         # adds memesh's hooks to ~/.claude/settings.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.1.5
+**Version**: 4.1.6
 
 ---
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.1.5
+**Version**: 4.1.6
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Adds the marketplace companion to v4.1.5's `.claude-plugin/plugin.json`
move. The repo now doubles as its own one-plugin marketplace, so users
can install memesh entirely from inside Claude Code:

```
/plugin marketplace add PCIRCLE-AI/memesh-llm-memory
/plugin install memesh@pcircle-ai
```

vs. the previous flow of `npm install -g @pcircle/memesh && memesh
install-hooks`. The npm path is preserved verbatim — this is an
additional install route, not a replacement.

## What's in this PR

- **`.claude-plugin/marketplace.json`** (new) — marketplace name
  `pcircle-ai`, one plugin entry pointing at `.` (this repo).
- **`.gitignore`** narrowed to no longer block `marketplace.json` (was
  a carry-over from when `.claude-plugin/` only meant local-dev plugin
  installs).
- **`package.json` + `.claude-plugin/plugin.json` + docs** bumped
  4.1.5 → 4.1.6.
- **README** restructured Get Started: Option A (Claude Code plugin)
  and Option B (npm global), with clear audience notes for each.
  Step 1.5 (`memesh install-hooks`) clarified as npm-path-only;
  Option A users get hook wiring automatically.

## Backward compatibility

- `npm install -g @pcircle/memesh` users: unaffected.
- `memesh install-hooks` users: unaffected.
- New install route via Claude Code's `/plugin install` — this is the
  use case v4.1.5 prepared the ground for.

## Test plan

- [x] `npm run build` smoke 6/6 pass
- [x] `verify-docs-sync.sh` all checks pass
- [x] marketplace.json valid JSON
- [x] Both `.claude-plugin/plugin.json` and `marketplace.json` tracked
- [ ] CI all green (this PR)
- [ ] Release-verify gate green (this PR)