### PR TITLE
release(4.1.7): rename marketplace identifier pcircle-ai -> pcircle-memesh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "pcircle-ai",
+  "name": "pcircle-memesh",
   "owner": {
     "name": "PCIRCLE AI"
   },
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.1.6",
+  "version": "4.1.7",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.1.7] — 2026-05-09
+
+Marketplace identifier renamed from `pcircle-ai` to `pcircle-memesh` to avoid name collision with sibling PCIRCLE AI plugin repos that also self-publish marketplaces named `pcircle-ai` (e.g. `toonify-mcp`, `claude-code-buddy`). Users with any of those marketplaces already registered hit `Plugin "memesh" not found in marketplace "pcircle-ai"` on `/plugin install` because Claude Code binds one repo per marketplace name on the local machine, and earlier siblings won the binding.
+
+### Changed
+- **Install command** (Option A — Claude Code plugin):
+  ```
+  /plugin marketplace add PCIRCLE-AI/memesh-llm-memory      # repo URL unchanged
+  /plugin install memesh@pcircle-memesh                      # was: memesh@pcircle-ai
+  ```
+  Only the marketplace identifier changed (`pcircle-ai` → `pcircle-memesh`). The plugin name (`memesh`) and the GitHub repo (`PCIRCLE-AI/memesh-llm-memory`) stay the same.
+- **`.claude-plugin/marketplace.json`** `name` field: `"pcircle-ai"` → `"pcircle-memesh"`. The marketplace is now uniquely identifiable per plugin, which lets a user have all PCIRCLE AI plugin marketplaces registered simultaneously without collision.
+
+### Migration for v4.1.6 plugin users
+If you ran `/plugin marketplace add PCIRCLE-AI/memesh-llm-memory` on v4.1.6, the registered marketplace name was `pcircle-ai`. After this release, run these once to switch to the new name:
+
+```
+/plugin marketplace remove pcircle-ai
+/plugin marketplace add PCIRCLE-AI/memesh-llm-memory
+/plugin install memesh@pcircle-memesh
+```
+
+The `marketplace add` step will register the marketplace under the new `pcircle-memesh` name (read from `marketplace.json`).
+
+### Backward compatibility
+- `npm install -g @pcircle/memesh` users (Option B): unaffected. CLI binaries and behaviour unchanged.
+- `memesh install-hooks` users: unaffected.
+- Existing `~/.memesh/knowledge-graph.db`: untouched.
+- The `.mcp.json` `npx -y -p @pcircle/memesh memesh-mcp` pattern from v4.1.6 stays — only the marketplace identifier changed.
+
 ## [4.1.6] — 2026-05-09
 
 Marketplace manifest + plugin-context MCP wiring. The Claude Code plugin install (Option A) now delivers the full memesh experience — hooks, skills, MCP tools, CLI, and dashboard — without requiring a separate `npm install -g`. Adopts the standard `npx -y` pattern used by other stdio MCP plugins so memesh works identically whether installed as a Claude Code plugin or as an npm global.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you use Claude Code, install MeMesh as a plugin from inside the CLI:
 
 ```
 /plugin marketplace add PCIRCLE-AI/memesh-llm-memory
-/plugin install memesh@pcircle-ai
+/plugin install memesh@pcircle-memesh
 ```
 
 Claude Code wires hooks, skills, and the MCP server automatically. You get in-session auto-capture, proactive recall, the `/memesh` skill (remember / recall / learn / forget) inside the Claude Code conversation, and `remember` / `recall` / `forget` / `learn` available as MCP tools to the agent. The CLI and the local dashboard are also fully accessible without any extra global install — `npx @pcircle/memesh <command>` runs every CLI command, and `npx @pcircle/memesh` launches the dashboard at `localhost:3737`. The MCP server uses the same `npx`-based launch pattern as Anthropic's official plugins (e.g. `context7`), so no `npm install -g` is needed for any feature.
@@ -69,7 +69,7 @@ npm install -g @pcircle/memesh
 
 ### Step 1.5: Wire MeMesh into Claude Code (npm path only)
 
-If you installed via **Option A** (`/plugin install memesh@pcircle-ai`), skip this step — Claude Code wires plugin hooks automatically.
+If you installed via **Option A** (`/plugin install memesh@pcircle-memesh`), skip this step — Claude Code wires plugin hooks automatically.
 
 If you installed via **Option B** (`npm install -g`), the CLI is on your PATH and the MCP server is registered, but the Claude Code session hooks are not auto-wired. Without them you can still use `memesh remember` / `recall` manually, but the **auto-capture loop** (sessions → lessons → recall on next session) is silent.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.1.6
+**Version**: 4.1.7
 
 ---
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.1.6
+**Version**: 4.1.7
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

v4.1.6 used `marketplace.json` name `pcircle-ai`, which collides with sibling PCIRCLE AI plugin repos (`toonify-mcp`, `claude-code-buddy`) that also self-publish marketplaces under the same name. Claude Code binds one repo per marketplace name on the local machine; if a user already had a different sibling marketplace registered as `pcircle-ai`, `/plugin install memesh@pcircle-ai` resolved against the older binding and returned `Plugin "memesh" not found in marketplace "pcircle-ai"`.

This release renames memesh's marketplace identifier from `pcircle-ai` to `pcircle-memesh` so the name is unique per plugin. A user can now register all PCIRCLE AI plugin marketplaces simultaneously without collision.

## What changes for users

| Surface | Before | After |
|---|---|---|
| Marketplace `name` | `pcircle-ai` | `pcircle-memesh` |
| Install command | `/plugin install memesh@pcircle-ai` | `/plugin install memesh@pcircle-memesh` |
| `/plugin marketplace add` URL | `PCIRCLE-AI/memesh-llm-memory` | unchanged |
| Plugin name | `memesh` | unchanged |
| npm package | `@pcircle/memesh` | unchanged |
| `.mcp.json` MCP launch | unchanged (`npx -y -p @pcircle/memesh memesh-mcp`) | unchanged |

## Files

- `.claude-plugin/marketplace.json` — `name` and plugin entry version updated
- `package.json` + `.claude-plugin/plugin.json` + `docs/ARCHITECTURE.md` + `docs/api/API_REFERENCE.md` — version 4.1.6 → 4.1.7
- `README.md` — install command updated, Step 1.5 reference updated
- `CHANGELOG.md` — `[4.1.7]` entry with explicit migration steps for v4.1.6 plugin users

## Migration for v4.1.6 plugin users

```
/plugin marketplace remove pcircle-ai
/plugin marketplace add PCIRCLE-AI/memesh-llm-memory
/plugin install memesh@pcircle-memesh
```

## Test plan
- [x] verify-docs-sync.sh PASS
- [x] All 5 version locations updated to 4.1.7
- [x] Pre-release content audit returned PASS
- [ ] CI green
- [ ] After merge, manual: `/plugin marketplace add PCIRCLE-AI/memesh-llm-memory` + `/plugin install memesh@pcircle-memesh` succeeds end-to-end