### PR TITLE
refactor(core): consolidate path resolution, migration chain, and scoring math

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,8 @@ src/
 │   ├── consolidator.ts    # LLM-powered observation compression (extracted from operations)
 │   ├── serializer.ts      # Export/import memory snapshots (extracted from operations)
 │   ├── config.ts          # Config management + capability detection + logCapabilities()
-│   ├── scoring.ts         # Multi-factor scoring engine (rankEntities)
+│   ├── paths.ts           # Centralised path helpers (homeDir, memeshDir, getDbPath, getProjectName)
+│   ├── scoring.ts         # Multi-factor scoring engine (rankEntities) + SESSION_START_WEIGHT_RATIO
 │   ├── query-expander.ts  # LLM query expansion (Level 1)
 │   ├── extractor.ts       # Session knowledge extraction (rule-based + LLM)
 │   ├── lifecycle.ts       # Auto-decay + consolidation orchestration
@@ -99,9 +100,13 @@ src/
 
 **operations.ts** — Pure functions implementing `remember`, `recall`, `forget`, `learn`, and others. All three transports delegate here — no transport-specific logic leaks into business logic.
 
-**config.ts** — Config management: reads `MEMESH_DB_PATH` and other environment variables, detects sqlite-vec availability, exposes a typed config object to transports and core functions. `logCapabilities()` logs detected search level and LLM provider to stderr on server startup (safe for MCP stdio transport).
+**config.ts** — Config management: reads `MEMESH_DB_PATH` and other environment variables, detects sqlite-vec availability, exposes a typed config object to transports and core functions. `logCapabilities()` logs detected search level and LLM provider to stderr on server startup (safe for MCP stdio transport). The on-disk config path is resolved lazily via `paths.ts:memeshDir()` so HOME-first override works in hermetic Windows tests.
 
-**scoring.ts** — Multi-factor scoring engine. `scoreEntity()` combines five signals: search relevance (0.35), recency via exponential decay (0.25), access frequency via log normalization (0.20), confidence (0.15), and temporal validity (0.05). `rankEntities()` sorts any entity list by score descending. Applied in all recall paths (`recall()` and `recallEnhanced()`).
+**paths.ts** — Centralised filesystem path resolution. Exports `homeDir()` (HOME-env-first override for testability), `memeshDir()` (MEMESH_DIR > `<home>/.memesh`), `getDbPath()` (MEMESH_DB_PATH > `<memeshDir>/knowledge-graph.db`), `getMemeshDirFromDbPath()` (parent dir of active DB file, used for sibling state files), and `getProjectName(cwdInput?)` (basename of explicit cwd or `process.cwd()`). Replaces 10+ inline `process.env.MEMESH_DB_PATH ?? path.join(os.homedir(), …)` patterns that had subtly different fallbacks. Hooks cannot import from `dist/` (the F5 boundary), so `scripts/hooks/_shared.js` keeps a mirror of these helpers; the JSDoc on each function cross-links to its core counterpart, and any change here MUST land in both files.
+
+**scoring.ts** — Multi-factor scoring engine. `scoreEntity()` combines five signals from `DEFAULT_WEIGHTS`: search relevance (0.30), recency via exponential decay (0.25), access frequency via log normalization (0.18), confidence (0.17), and recall-effectiveness impact via Laplace smoothing (0.10). `rankEntities()` sorts any entity list by score descending. Applied in all recall paths (`recall()` and `recallEnhanced()`).
+
+Session-start hook ranking is a SQL-only subset (no FTS query, no impact pass) that uses three of the five factors. `SESSION_START_WEIGHT_RATIO` exports the renormalised weights so the hook's hard-coded SQL stays in sync; a drift-guard test in `tests/core/scoring.test.ts` asserts the magic numbers in `scripts/hooks/session-start.js` match. The hook SQL uses SQLite's `exp()`/`log()` (available in better-sqlite3 v8+) to match the core math exactly, with a runtime probe + linear/rational fallback for stripped-down builds without `-DSQLITE_ENABLE_MATH_FUNCTIONS`.
 
 **query-expander.ts** — LLM-powered query expansion (Level 1). When a LLM is configured (Anthropic, OpenAI, or Ollama), `expandQuery()` generates related search terms for a user query. Results from expanded terms are merged with original-query results and re-ranked by score (original query = 1.0 relevance, expanded terms = 0.7 relevance).
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node scripts/copy-cli-assets.mjs && node scripts/set-executable-bits.mjs && node scripts/generate-skills-manifest.mjs && npm run build:dashboard && node scripts/smoke-test.mjs",
+    "build": "node scripts/check-schema-drift.mjs && tsc && node scripts/copy-cli-assets.mjs && node scripts/set-executable-bits.mjs && node scripts/generate-skills-manifest.mjs && npm run build:dashboard && node scripts/smoke-test.mjs",
     "build:dashboard": "node scripts/build-dashboard.mjs",
     "test": "vitest",
     "test:e2e-dashboard": "node scripts/dashboard-e2e-smoke.mjs",

--- a/scripts/check-schema-drift.mjs
+++ b/scripts/check-schema-drift.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+//
+// Schema-drift guard
+// ==================
+//
+// `src/db.ts` and `scripts/hooks/_shared.js` carry byte-for-byte identical
+// SCHEMA_SQL + FTS_SQL strings. The duplication is structurally necessary —
+// hooks cannot import from `dist/` (the F5 security boundary), so the SQL
+// has to be embedded in the hook-side helper.
+//
+// Two engineers working on different copies have repeatedly let them
+// drift in the past (the comment in _shared.js explicitly documents
+// "must change in lockstep"). This script enforces the invariant at
+// build time: it extracts both strings, normalises whitespace, diffs
+// them, and exits non-zero on any divergence.
+//
+// Wired into `npm run build` as a prebuild step. Also runnable
+// standalone:
+//
+//   node scripts/check-schema-drift.mjs
+//
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+const CORE_PATH = resolve(repoRoot, 'src/db.ts');
+const HOOK_PATH = resolve(repoRoot, 'scripts/hooks/_shared.js');
+
+/**
+ * Pull a top-level template-literal constant by its identifier.
+ * Both files declare `const SCHEMA_SQL = \`…\`;` and `const FTS_SQL = \`…\`;`
+ * (with `export` prefix on the hook side). Regex captures the body between
+ * the surrounding backticks.
+ */
+function extractConstant(source, name) {
+  const re = new RegExp(
+    String.raw`(?:export\s+)?const\s+` + name + String.raw`\s*=\s*\x60([\s\S]*?)\x60\s*;`,
+    'm',
+  );
+  const match = source.match(re);
+  if (!match) {
+    throw new Error(`Could not locate \`${name}\` template literal`);
+  }
+  return match[1];
+}
+
+/**
+ * Whitespace-only differences are not drift — collapse runs of whitespace
+ * to a single space and trim. Anything else (different column, missing
+ * index, wrong table name, …) survives normalisation and the diff fires.
+ */
+function normalise(sql) {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+function readFile(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (err) {
+    console.error(`schema-drift: cannot read ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+const coreSrc = readFile(CORE_PATH);
+const hookSrc = readFile(HOOK_PATH);
+
+const failures = [];
+
+for (const name of ['SCHEMA_SQL', 'FTS_SQL']) {
+  let coreVal;
+  let hookVal;
+  try {
+    coreVal = extractConstant(coreSrc, name);
+  } catch (err) {
+    failures.push(`${CORE_PATH}: ${err.message}`);
+    continue;
+  }
+  try {
+    hookVal = extractConstant(hookSrc, name);
+  } catch (err) {
+    failures.push(`${HOOK_PATH}: ${err.message}`);
+    continue;
+  }
+  if (normalise(coreVal) !== normalise(hookVal)) {
+    failures.push(
+      `${name} drift detected between ${CORE_PATH} and ${HOOK_PATH}.\n` +
+      `  Run a side-by-side diff and bring the two definitions back in sync.\n` +
+      `  Both files must declare an identical ${name} template literal.`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('\n✗ schema-drift check FAILED:\n');
+  for (const f of failures) console.error(`  ${f}\n`);
+  process.exit(1);
+}
+
+console.log('✓ schema-drift check passed (SCHEMA_SQL + FTS_SQL match)');

--- a/scripts/hooks/_shared.js
+++ b/scripts/hooks/_shared.js
@@ -2,10 +2,25 @@ import { appendFileSync, chmodSync, closeSync, existsSync, mkdirSync, openSync, 
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import { homedir } from 'os';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const require = createRequire(import.meta.url);
+
+// =============================================================================
+// Path helpers — MIRROR of src/core/paths.ts
+// =============================================================================
+//
+// Hooks cannot import from `dist/` (the F5 security boundary — `dist/` may
+// be stale or absent at hook execution time), so the path-resolution logic
+// is duplicated here. The contract MUST stay in lockstep with
+// `src/core/paths.ts`. Any change to the function shapes / precedence
+// rules in that file MUST be reflected here too.
+//
+// Unlike the schema duplication (which has a build-time diff guard via
+// `scripts/check-schema-drift.mjs`), these helpers are short enough that
+// human review at code-review time is sufficient. If they grow, add a
+// programmatic guard.
 
 /**
  * Return the user's home directory, honoring HOME env var first.
@@ -17,10 +32,61 @@ const require = createRequire(import.meta.url);
  * across platforms. Production users on Windows almost never set HOME,
  * so this falls through to os.homedir() as before.
  *
+ * Mirror of: src/core/paths.ts → homeDir()
+ *
  * @returns {string}
  */
 function homeDir() {
   return process.env.HOME ?? homedir();
+}
+
+/**
+ * Resolve the memesh data directory.
+ *
+ * Precedence: MEMESH_DIR env var > <home>/.memesh.
+ * Mirror of: src/core/paths.ts → memeshDir()
+ *
+ * No-arg to mirror the core helper exactly. Earlier drafts accepted a
+ * custom `env` parameter for symmetry with `getMemeshDirFromDbPath(env)`,
+ * but the inner `homeDir()` only ever read `process.env.HOME`, so a
+ * caller that passed `{HOME: '/tmp/x'}` would be silently ignored — a
+ * footgun. Tests redirect via `process.env.HOME`; that's the supported
+ * extension point.
+ *
+ * @returns {string}
+ */
+export function memeshDir() {
+  return process.env.MEMESH_DIR ?? join(homeDir(), '.memesh');
+}
+
+/**
+ * Resolve the active memesh DB path.
+ *
+ * Precedence: MEMESH_DB_PATH env var > <memeshDir>/knowledge-graph.db.
+ * Mirror of: src/core/paths.ts → getDbPath() — no-arg, see memeshDir().
+ *
+ * @returns {string}
+ */
+export function getDbPath() {
+  return process.env.MEMESH_DB_PATH ?? join(memeshDir(), 'knowledge-graph.db');
+}
+
+/**
+ * Derive the project name from a working directory.
+ *
+ * Hooks historically used `basename(data.cwd || process.cwd())`. Core
+ * had two variants (`basename(context.cwd)` and `basename(process.cwd())`).
+ * This helper unifies the contract — explicit cwd wins, falls through to
+ * process.cwd() — matching the most permissive caller's behaviour.
+ *
+ * Mirror of: src/core/paths.ts → getProjectName()
+ *
+ * @param {string|null|undefined} [cwdInput]
+ * @returns {string}
+ */
+export function getProjectName(cwdInput) {
+  const cwd = cwdInput && cwdInput.length > 0 ? cwdInput : process.cwd();
+  return basename(cwd);
 }
 
 /**
@@ -64,7 +130,7 @@ export function resolvePluginRoot(metaUrl) {
  * @returns {Record<string, any>}
  */
 export function readHookConfig(_env = process.env) {
-  const path = join(homeDir(), '.memesh', 'config.json');
+  const path = join(memeshDir(), 'config.json');
   if (!existsSync(path)) return {};
   try {
     const raw = readFileSync(path, 'utf8');
@@ -233,22 +299,91 @@ CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
  * @param {boolean} [opts.fts=false] - Also create the FTS5 virtual table.
  * @returns {{ db: any, dbPath: string }}
  */
+// Cached lookup for the better-sqlite3 native module. Plugin-marketplace
+// installs ship the tarball without node_modules, so the cache copy of the
+// hook scripts cannot resolve the binding. tryRequireBetterSqlite() returns
+// null in that scenario and lets each caller silent-skip — callers paired
+// with a working dev/npm-global registration still produce output.
+let _cachedDatabaseCtor;
+export function tryRequireBetterSqlite() {
+  // Test-only seam: force the "native module unavailable" branch so
+  // tests can exercise the silent-skip path that plugin-marketplace
+  // cache installs hit. Production callers never set this var.
+  if (process.env.MEMESH_TEST_FORCE_MISSING_NATIVE === '1') return null;
+  if (_cachedDatabaseCtor !== undefined) return _cachedDatabaseCtor;
+  try {
+    _cachedDatabaseCtor = require('better-sqlite3');
+  } catch {
+    _cachedDatabaseCtor = null;
+  }
+  return _cachedDatabaseCtor;
+}
+
 export function openHookDb(env = process.env, opts = {}) {
-  const dbPath = env.MEMESH_DB_PATH || join(homeDir(), '.memesh', 'knowledge-graph.db');
-  const dbDir = env.MEMESH_DB_PATH ? dirname(env.MEMESH_DB_PATH) : join(homeDir(), '.memesh');
+  const Database = tryRequireBetterSqlite();
+  if (!Database) return null;
+
+  const dbPath = getDbPath(env);
+  const dbDir = env.MEMESH_DB_PATH ? dirname(env.MEMESH_DB_PATH) : memeshDir(env);
   if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
 
-  const Database = require('better-sqlite3');
   const db = new Database(dbPath);
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   db.exec(SCHEMA_SQL);
   if (opts.fts) db.exec(FTS_SQL);
 
+  // Apply the full migration chain — keep in lockstep with src/db.ts.
+  // Conditional ALTER TABLE blocks ARE idempotent within a single process,
+  // but two hook processes can race: each reads `colNames` from its own
+  // PRAGMA snapshot, so both see "column missing" and both run ALTER —
+  // the second one throws SQLITE_ERROR: duplicate column name. Each ALTER
+  // is wrapped in safeAlter() which treats that specific error as the
+  // expected no-op outcome (a peer beat us to it). Any other error
+  // re-throws so we don't paper over real bugs.
+  //
+  // Earlier this helper applied ONLY the v2.11->v2.12 status migration.
+  // That left a hook-only-touched DB at v2.12 even though core was at
+  // v4.0+, so session-start fell back to `ORDER BY id DESC` (degraded
+  // ranking) until the CLI/MCP/HTTP first opened the DB and finished
+  // the chain. Backfilled here so write-path hooks produce the same
+  // schema state as core.
+  const safeAlter = (sql) => {
+    try {
+      db.exec(sql);
+    } catch (e) {
+      if (!/duplicate column name/i.test(e?.message || '')) throw e;
+      // Peer hook process won the race; column already exists. Idempotent.
+    }
+  };
   const cols = db.prepare("PRAGMA table_info(entities)").all();
-  if (!cols.some((c) => c.name === 'status')) {
-    db.exec("ALTER TABLE entities ADD COLUMN status TEXT NOT NULL DEFAULT 'active'");
+  const colNames = new Set(cols.map((c) => c.name));
+
+  // v2.11 -> v2.12: status
+  if (!colNames.has('status')) {
+    safeAlter("ALTER TABLE entities ADD COLUMN status TEXT NOT NULL DEFAULT 'active'");
     db.exec("CREATE INDEX IF NOT EXISTS idx_entities_status ON entities(status)");
+  }
+
+  // v2.14 -> v2.15: scoring + temporal-validity columns
+  if (!colNames.has('access_count')) {
+    safeAlter("ALTER TABLE entities ADD COLUMN access_count INTEGER DEFAULT 0");
+    safeAlter("ALTER TABLE entities ADD COLUMN last_accessed_at TIMESTAMP");
+    safeAlter("ALTER TABLE entities ADD COLUMN confidence REAL DEFAULT 1.0");
+    safeAlter("ALTER TABLE entities ADD COLUMN valid_from TIMESTAMP");
+    safeAlter("ALTER TABLE entities ADD COLUMN valid_until TIMESTAMP");
+  }
+
+  // v3.0.0-rc -> v3.0.0: namespace
+  if (!colNames.has('namespace')) {
+    safeAlter("ALTER TABLE entities ADD COLUMN namespace TEXT DEFAULT 'personal'");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace)");
+  }
+
+  // v4.0.0: recall effectiveness counters
+  if (!colNames.has('recall_hits')) {
+    safeAlter("ALTER TABLE entities ADD COLUMN recall_hits INTEGER DEFAULT 0");
+    safeAlter("ALTER TABLE entities ADD COLUMN recall_misses INTEGER DEFAULT 0");
   }
 
   return { db, dbPath };
@@ -257,8 +392,20 @@ export function openHookDb(env = process.env, opts = {}) {
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
 
-export function getMemeshDir(env = process.env) {
-  return env.MEMESH_DB_PATH ? dirname(env.MEMESH_DB_PATH) : join(homeDir(), '.memesh');
+/**
+ * Resolve the directory containing the active DB file.
+ *
+ * When MEMESH_DB_PATH is set, returns its parent directory (used for
+ * sibling files next to the DB). Otherwise returns memeshDir().
+ * Mirror of: src/core/paths.ts → getMemeshDirFromDbPath()
+ *
+ * Renamed from the legacy `getMemeshDir` to match the core helper —
+ * sibling helper `memeshDir()` returns the GLOBAL data directory, so a
+ * second function called `getMemeshDir` was confusing. Callers updated
+ * in lockstep.
+ */
+export function getMemeshDirFromDbPath() {
+  return process.env.MEMESH_DB_PATH ? dirname(process.env.MEMESH_DB_PATH) : memeshDir();
 }
 
 export function ensurePrivateDir(dirPath) {
@@ -332,7 +479,7 @@ export function readUpdateCheckCache(installedVersion) {
     && /^[0-9A-Za-z.+-]+$/.test(installedVersion)
     ? installedVersion
     : 'unknown';
-  const cachePath = join(homeDir(), '.memesh', `update-check.${versionTag}.json`);
+  const cachePath = join(memeshDir(), `update-check.${versionTag}.json`);
   try {
     if (!existsSync(cachePath)) return null;
     const parsed = JSON.parse(readFileSync(cachePath, 'utf8'));
@@ -391,7 +538,7 @@ export function decideAutoUpdateHook(currentVersion, cache, policy) {
 
 export function logAutoUpdate(line) {
   try {
-    const dir = getMemeshDir(process.env);
+    const dir = getMemeshDirFromDbPath();
     ensurePrivateDir(dir);
     const path = join(dir, 'auto-update.log');
     appendFileSync(path, `[${new Date().toISOString()}] ${line}\n`);
@@ -405,7 +552,7 @@ export const AUTO_UPDATE_LOCK_TTL_MS = 10 * 60 * 1000;
 
 export function tryAcquireAutoUpdateLock(version) {
   try {
-    const dir = join(homeDir(), '.memesh');
+    const dir = memeshDir();
     ensurePrivateDir(dir);
     const lockPath = join(dir, 'auto-update.lock');
     const fs = require('fs');
@@ -490,7 +637,7 @@ export function spawnAutoUpdate(version, deprecationOverride, installChannelMod)
       );
       return { state: 'in-progress' };
     }
-    const dir = getMemeshDir(process.env);
+    const dir = getMemeshDirFromDbPath();
     ensurePrivateDir(dir);
     const logPath = join(dir, 'auto-update.log');
     let fd = -1;

--- a/scripts/hooks/_shared.js
+++ b/scripts/hooks/_shared.js
@@ -323,8 +323,13 @@ export function openHookDb(env = process.env, opts = {}) {
   const Database = tryRequireBetterSqlite();
   if (!Database) return null;
 
-  const dbPath = getDbPath(env);
-  const dbDir = env.MEMESH_DB_PATH ? dirname(env.MEMESH_DB_PATH) : memeshDir(env);
+  // Path helpers read process.env directly (no-arg). The `env` parameter
+  // is kept on this signature for backward compatibility with callers
+  // and is consulted directly only for the DB-PATH dirname check below
+  // — that's the one place where a caller's custom env should win over
+  // process.env (e.g. the test harness redirects MEMESH_DB_PATH per test).
+  const dbPath = env.MEMESH_DB_PATH ?? getDbPath();
+  const dbDir = env.MEMESH_DB_PATH ? dirname(env.MEMESH_DB_PATH) : memeshDir();
   if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
 
   const db = new Database(dbPath);

--- a/scripts/hooks/post-commit.js
+++ b/scripts/hooks/post-commit.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'child_process';
-import { basename } from 'path';
-import { openHookDb } from './_shared.js';
+import { getProjectName, openHookDb } from './_shared.js';
 
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -27,11 +26,17 @@ process.stdin.on('end', () => {
 
     const commitHash = commitMatch[1];
     const commitMsg = commitMatch[2];
-    const projectName = basename(data.cwd || process.cwd());
+    const projectName = getProjectName(data.cwd);
 
     // Open DB via shared helper — applies SCHEMA_SQL + status migration.
     // Pass fts:true so the FTS5 entity-search index is also available.
-    const { db } = openHookDb(process.env, { fts: true });
+    // Returns null when the better-sqlite3 native module is unavailable
+    // (e.g. plugin-marketplace cache install with no node_modules); in
+    // that case silently skip — a sibling registered hook copy with
+    // proper deps still records the commit.
+    const handle = openHookDb(process.env, { fts: true });
+    if (!handle) return;
+    const { db } = handle;
     try {
       const entityName = `commit-${commitHash}`;
 

--- a/scripts/hooks/pre-bash-orchestration-nudge.js
+++ b/scripts/hooks/pre-bash-orchestration-nudge.js
@@ -13,9 +13,9 @@
 
 import { join } from 'path';
 import { openSync, closeSync } from 'fs';
-import { ensurePrivateDir, getMemeshDir, isAgenticOrchestrationEnabled } from './_shared.js';
+import { ensurePrivateDir, getMemeshDirFromDbPath, isAgenticOrchestrationEnabled } from './_shared.js';
 
-const memeshDir = getMemeshDir(process.env);
+const memeshDir = getMemeshDirFromDbPath();
 const FLAGS_DIR = join(memeshDir, 'agent-nudge-flags');
 
 // ---------------------------------------------------------------------------

--- a/scripts/hooks/pre-compact.js
+++ b/scripts/hooks/pre-compact.js
@@ -2,7 +2,7 @@
 
 import { basename } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { isAutoCaptureEnabled, openHookDb } from './_shared.js';
+import { getProjectName, isAutoCaptureEnabled, openHookDb } from './_shared.js';
 
 // Timeout guard: always exit within 10 seconds
 const TIMEOUT_MS = 10000;
@@ -27,7 +27,7 @@ process.stdin.on('end', () => {
     const transcriptPath = data.transcript_path || '';
     const cwd = data.cwd || process.cwd();
     const reason = data.reason || 'auto';
-    const projectName = basename(cwd);
+    const projectName = getProjectName(cwd);
 
     // Parse transcript to gather insights
     let toolCallCount = 0;
@@ -84,7 +84,11 @@ process.stdin.on('end', () => {
 
     // Open DB via shared helper — applies SCHEMA_SQL + status migration.
     // FTS5 needed for the entity-search index updates below.
-    const { db } = openHookDb(process.env, { fts: true });
+    // Returns null on plugin-marketplace cache installs without node_modules;
+    // silently skip in that case (sibling registered copy handles it).
+    const handle = openHookDb(process.env, { fts: true });
+    if (!handle) return;
+    const { db } = handle;
     try {
       // Upsert entity
       const insertResult = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)').run(entityName, 'session-summary');

--- a/scripts/hooks/pre-edit-recall.js
+++ b/scripts/hooks/pre-edit-recall.js
@@ -5,21 +5,23 @@
 // and injects them as context. Throttled: max 1 recall per file per session.
 
 import { createRequire } from 'module';
-import { homedir } from 'os';
-import { join, basename } from 'path';
+import { basename, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import {
   buildReferenceContext,
   ensurePrivateDir,
-  getMemeshDir,
+  getDbPath,
+  getMemeshDirFromDbPath,
+  getProjectName,
   isTrustedForAutoContext,
+  tryRequireBetterSqlite,
   writePrivateJson,
 } from './_shared.js';
 
 const require = createRequire(import.meta.url);
 
-const dbPath = process.env.MEMESH_DB_PATH || join(homedir(), '.memesh', 'knowledge-graph.db');
-const memeshDir = getMemeshDir(process.env);
+const dbPath = getDbPath();
+const memeshDir = getMemeshDirFromDbPath();
 const THROTTLE_FILE = join(memeshDir, 'session-recalled-files.json');
 const MAX_RESULTS = 3;
 
@@ -38,7 +40,7 @@ process.stdin.on('end', () => {
     }
 
     // Get project name from cwd for project-scoped filtering
-    const projectName = basename(data.cwd || process.cwd());
+    const projectName = getProjectName(data.cwd);
 
     // Throttle: skip if we already recalled for this file
     const fileKey = filePath.toLowerCase();
@@ -58,7 +60,12 @@ process.stdin.on('end', () => {
 
     if (!existsSync(dbPath)) return pass();
 
-    const Database = require('better-sqlite3');
+    // tryRequireBetterSqlite() returns null on plugin-marketplace cache
+    // installs that ship without node_modules; pass-through silently in
+    // that case so a sibling registered hook copy can still inject
+    // recall context.
+    const Database = tryRequireBetterSqlite();
+    if (!Database) return pass();
     const db = new Database(dbPath, { readonly: true });
     try {
 
@@ -155,8 +162,13 @@ process.stdin.on('end', () => {
     } finally {
       db.close();
     }
-  } catch {
-    // Never crash Claude Code
+  } catch (err) {
+    // Never crash Claude Code, but trace — peer hooks (post-commit,
+    // pre-compact, session-summary) all stderr-trace their outer
+    // catches. Without a trace here, a typo in any prepare statement
+    // would silently break continuous recall on every Edit/Write
+    // tool call indefinitely.
+    try { process.stderr.write(`[memesh pre-edit-recall] ${err?.message || err}\n`); } catch {}
     pass();
   }
 });

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -4,18 +4,20 @@ import { createRequire } from 'module';
 import { spawn } from 'child_process';
 import { createHash } from 'crypto';
 import { homedir } from 'os';
-import { join, basename } from 'path';
+import { join } from 'path';
 import { pathToFileURL } from 'url';
 import { existsSync, readFileSync, unlinkSync, rmSync, appendFileSync, chmodSync } from 'fs';
 import {
-  buildReferenceContext,
   ensurePrivateDir,
-  getMemeshDir,
+  getDbPath,
+  getMemeshDirFromDbPath,
+  getProjectName,
   isAgenticOrchestrationEnabled,
   isTrustedForAutoContext,
   readUpdateCheckCache,
   resolvePluginRoot,
   resolveSessionLimit,
+  tryRequireBetterSqlite,
   writePrivateJson,
 } from './_shared.js';
 
@@ -38,8 +40,8 @@ try {
   }
 } catch { /* best-effort — fall through to 'unknown' channel */ }
 
-const dbPath = process.env.MEMESH_DB_PATH || join(homedir(), '.memesh', 'knowledge-graph.db');
-const memeshDir = getMemeshDir(process.env);
+const dbPath = getDbPath();
+const memeshDir = getMemeshDirFromDbPath();
 const throttlePath = join(memeshDir, 'session-recalled-files.json');
 const nudgeFlagsDir = join(memeshDir, 'agent-nudge-flags');
 
@@ -178,7 +180,13 @@ function detectInstallChannelHook(pluginRoot) {
   if (!_installChannelMod) return 'unknown';
   try {
     return _installChannelMod.getCurrentInstallChannel({ packageRoot: pluginRoot });
-  } catch {
+  } catch (err) {
+    // Falling back to 'unknown' silences the deprecation banner's
+    // remediation hint (since it's gated on channel detection). When
+    // there's an active security-advisory deprecation, that's a
+    // user-visible regression — surface to stderr at least once per
+    // process so the reason is visible.
+    try { process.stderr.write(`[memesh session-start] install-channel detection: ${err?.message || err}\n`); } catch {}
     return 'unknown';
   }
 }
@@ -342,7 +350,7 @@ process.stdin.on('end', async () => {
   try {
     try {
     const data = JSON.parse(input);
-    const projectName = basename(data.cwd || process.cwd());
+    const projectName = getProjectName(data.cwd);
 
     // Clear per-session throttle files from previous session
     try {
@@ -364,11 +372,16 @@ process.stdin.on('end', async () => {
       // Combine deprecation banner (if any) into the same
       // systemMessage so stdout stays a single JSON document. Outer
       // finally runs runPostBannerUpdateTasks().
-      output(combineWithBanner('MeMesh: No database found. Memories will be created as you work.'));
+      output(combineWithBanner('◉ MeMesh ready · no database yet, memories will be created as you work'));
       return;
     }
 
-    const Database = require('better-sqlite3');
+    // Native module unavailable (typical for plugin-marketplace cache
+    // installs that ship without node_modules). Silently skip — the
+    // plugin's own MCP server runs via npx and a sibling registered
+    // copy of this hook (npm-global / dev path) supplies the summary.
+    const Database = tryRequireBetterSqlite();
+    if (!Database) return;
     const db = new Database(dbPath, { readonly: true });
     try {
       db.pragma('journal_mode = WAL');
@@ -378,7 +391,7 @@ process.stdin.on('end', async () => {
         "SELECT name FROM sqlite_master WHERE type='table' AND name='entities'"
       ).get();
       if (!tableCheck) {
-        output(combineWithBanner('MeMesh: Database exists but no memories stored yet.'));
+        output(combineWithBanner('◉ MeMesh ready · database initialised but no memories stored yet'));
         return;
       }
 
@@ -390,190 +403,166 @@ process.stdin.on('end', async () => {
       const hasScoringCols = colNames.has('access_count') && colNames.has('last_accessed_at') && colNames.has('confidence');
 
       const statusFilter = hasStatus ? "AND e.status = 'active'" : '';
-      const recentStatusFilter = hasStatus ? "WHERE status = 'active'" : '';
+      // (Note: a previous `recentStatusFilter` constant lived here; the
+      // refactor that introduced `buildScoringQuery` aliased the table
+      // as `e` for both the project- and recent-pool queries, so the
+      // bare-column `WHERE status = 'active'` form was replaced by the
+      // qualified `WHERE e.status = 'active'` computed inline below.)
 
       // Configurable limit: how many top-N entities to load per section.
       // Env > config.sessionLimit > default 10.
       const sessionLimit = resolveSessionLimit(process.env);
 
-      // Build scoring ORDER BY clause (or fallback to insertion order)
-      const scoringOrderBy = hasScoringCols
-        ? `ORDER BY
-            CASE WHEN e.confidence IS NULL THEN 0.5 ELSE e.confidence END * 0.4
+      // Scoring math is aligned to src/core/scoring.ts exactly:
+      //   - confidence  weight 0.2833  (core 0.17 / 0.60 sub-total)
+      //   - frequency   weight 0.3000  (core 0.18 / 0.60)
+      //   - recency     weight 0.4167  (core 0.25 / 0.60)
+      // Sub-total excludes searchRelevance + impact, which session-start
+      // can't compute without an FTS query. The renormalised ratios are
+      // exported from core/scoring.ts as `SESSION_START_WEIGHT_RATIO`;
+      // a drift-guard test in tests/core/scoring.test.ts asserts the SQL
+      // here stays in sync.
+      //
+      // Functions:
+      //   - frequency: log(c+1) / log(max(maxAccess,1) + 1)  (matches frequencyScore)
+      //   - recency:   exp(-(now - lastAccessed_days) / 30)  (matches recencyScore)
+      // SQLite >= 3.35 with -DSQLITE_ENABLE_MATH_FUNCTIONS provides exp/log;
+      // better-sqlite3 v8+ ships with this flag enabled by default. We probe
+      // once per process and fall back to the legacy linear/rational forms
+      // if a stripped-down build is detected, so ranking degrades gracefully
+      // rather than throwing.
+      // Test-only seam: force the legacy linear/rational fallback so the
+      // pre-math-functions code path is reachable in CI on builds where
+      // exp/log ARE available. Production callers never set this.
+      let hasSqliteMath = false;
+      if (process.env.MEMESH_TEST_FORCE_LEGACY_SCORING_SQL !== '1') {
+        try {
+          db.prepare('SELECT exp(1.0), log(2.0)').get();
+          hasSqliteMath = true;
+        } catch {
+          // Legacy SQLite build without math functions — keep linear fallback.
+        }
+      }
+
+      // The legacy schema (createTestDb in tests, plus very old installs)
+      // doesn't have confidence/access_count/last_accessed_at, so the
+      // SELECT can't reference them. Build the column list to match
+      // what the schema actually supports.
+      const baseCols = 'e.id, e.name, e.type, e.created_at, e.metadata';
+      const scoringCols = hasScoringCols
+        ? `, e.confidence, e.access_count, e.last_accessed_at`
+        : '';
+
+      const buildScoringQuery = (joinClause, whereClause) => {
+        const poolSelect = `SELECT DISTINCT ${baseCols}${scoringCols} FROM entities e ${joinClause}`;
+        if (!hasScoringCols) {
+          return `${poolSelect} ${whereClause} ORDER BY e.id DESC LIMIT ?`;
+        }
+        if (hasSqliteMath) {
+          return `WITH pool AS (
+              ${poolSelect} ${whereClause}
+            ),
+            pool_stats AS (
+              SELECT COALESCE(MAX(access_count), 0) AS max_access FROM pool
+            )
+            SELECT p.id, p.name, p.type, p.created_at, p.metadata
+            FROM pool p, pool_stats s
+            ORDER BY
+              COALESCE(p.confidence, 1.0) * 0.2833
+              + (CASE WHEN s.max_access <= 0 THEN 0
+                      ELSE log(COALESCE(p.access_count, 0) + 1) / log(max(s.max_access, 1) + 1) END) * 0.3000
+              + (CASE WHEN p.last_accessed_at IS NULL THEN 0.5
+                      ELSE exp(-(julianday('now') - julianday(p.last_accessed_at)) / 30.0) END) * 0.4167
+              DESC
+            LIMIT ?`;
+        }
+        // Legacy fallback (SQLite without math functions): linear cap + rational decay.
+        // Same direction as core ranking; absolute scores differ slightly.
+        return `${poolSelect} ${whereClause}
+          ORDER BY
+            COALESCE(e.confidence, 1.0) * 0.2833
             + CASE WHEN e.access_count IS NULL THEN 0
-                   ELSE MIN(CAST(e.access_count AS REAL) / 50.0, 1.0) END * 0.3
-            + CASE WHEN e.last_accessed_at IS NULL THEN 0.3
-                   ELSE MIN(1.0, 1.0 / (1.0 + (julianday('now') - julianday(e.last_accessed_at)) / 30.0)) END * 0.3
-            DESC`
-        : 'ORDER BY e.id DESC';
+                   ELSE MIN(CAST(e.access_count AS REAL) / 50.0, 1.0) END * 0.3000
+            + CASE WHEN e.last_accessed_at IS NULL THEN 0.5
+                   ELSE MIN(1.0, 1.0 / (1.0 + (julianday('now') - julianday(e.last_accessed_at)) / 30.0)) END * 0.4167
+            DESC
+          LIMIT ?`;
+      };
 
-      const recentScoringOrderBy = hasScoringCols
-        ? `ORDER BY
-            CASE WHEN confidence IS NULL THEN 0.5 ELSE confidence END * 0.4
-            + CASE WHEN access_count IS NULL THEN 0
-                   ELSE MIN(CAST(access_count AS REAL) / 50.0, 1.0) END * 0.3
-            + CASE WHEN last_accessed_at IS NULL THEN 0.3
-                   ELSE MIN(1.0, 1.0 / (1.0 + (julianday('now') - julianday(last_accessed_at)) / 30.0)) END * 0.3
-            DESC`
-        : 'ORDER BY id DESC';
-
-      // Query project-specific top-N entities by relevance score
       const projectTag = `project:${projectName}`;
-      const projectEntities = db.prepare(`
-        SELECT DISTINCT e.id, e.name, e.type, e.created_at, e.metadata
-        FROM entities e
-        JOIN tags t ON t.entity_id = e.id
-        WHERE t.tag = ?
-        ${statusFilter}
-        ${scoringOrderBy}
-        LIMIT ?
-      `).all(projectTag, sessionLimit * 3)
+      const projectQuery = buildScoringQuery(
+        `JOIN tags t ON t.entity_id = e.id`,
+        `WHERE t.tag = ? ${statusFilter}`,
+      );
+      const projectEntities = db.prepare(projectQuery).all(projectTag, sessionLimit * 3)
         .filter(entity => isTrustedForAutoContext(entity.metadata))
         .slice(0, sessionLimit);
 
-      // Fetch the first observation for each entity (for concise summary)
-      const getFirstObservation = db.prepare(
-        'SELECT content FROM observations WHERE entity_id = ? ORDER BY id ASC LIMIT 1'
-      );
-
-      // Query global recent/top entities (exclude project-tagged ones for this project)
-      const recentEntities = db.prepare(`
-        SELECT id, name, type, created_at, metadata
-        FROM entities
-        ${recentStatusFilter}
-        ${recentScoringOrderBy}
-        LIMIT 15
-      `).all()
+      // recentStatusFilter is "WHERE status = 'active'" or "" — the bare-column
+      // form is fine when there's no JOIN, but we now alias the table as `e`,
+      // so rewrite to e.status for consistency.
+      const recentWhere = hasStatus ? "WHERE e.status = 'active'" : '';
+      const recentQuery = buildScoringQuery('', recentWhere);
+      const recentEntities = db.prepare(recentQuery).all(15)
         .filter(entity => isTrustedForAutoContext(entity.metadata))
         .slice(0, 5);
 
-      // Format entity as concise bullet: "• name (type): first observation (truncated)"
-      function formatEntity(entity) {
-        const obs = getFirstObservation.get(entity.id);
-        const snippet = obs ? obs.content.slice(0, 100) : '';
-        return snippet
-          ? `• ${entity.name} (${entity.type}): ${snippet}`
-          : `• ${entity.name} (${entity.type})`;
-      }
-
-      // Build recall message
-      const lines = [];
-      if (projectEntities.length > 0) {
-        const label = hasScoringCols ? `top ${projectEntities.length} by relevance` : `${projectEntities.length}`;
-        lines.push(`Project "${projectName}" memories (${label}):`);
-        for (const e of projectEntities) {
-          lines.push(formatEntity(e));
-        }
-      }
-      if (recentEntities.length > 0) {
-        if (lines.length > 0) lines.push('');
-        lines.push('Recent memories:');
-        for (const e of recentEntities) {
-          lines.push(formatEntity(e));
-        }
-      }
-
-      // No memories at all — surface only the deprecation banner if
-      // active (so a flagged install still warns the user) and skip
-      // the rest of the recall-summary work. The outer finally still
-      // runs runPostBannerUpdateTasks().
-      if (lines.length === 0) {
-        const bannerOnly = combineWithBanner('');
-        if (bannerOnly && bannerOnly.trim().length > 0) {
-          output(bannerOnly.trim());
-        }
-        return;
-      }
-
-      let memorySummary = lines.join('\n');
-
-      // --- Proactive lesson warnings ---
+      // Lesson count (queried for summary, not listed individually).
+      // Status-column gate matches the project/recent queries above —
+      // legacy v2.11 schemas don't have e.status and would otherwise
+      // throw `no such column: status`, hiding lessons from session-start
+      // auto-context indefinitely.
+      let lessonCount = 0;
       try {
-        const lessonEntities = db.prepare(`
-          SELECT DISTINCT e.id, e.name, e.confidence, e.metadata
+        const lessonRows = db.prepare(`
+          SELECT DISTINCT e.id, e.metadata
           FROM entities e
           JOIN tags t ON t.entity_id = e.id
           WHERE e.type = 'lesson_learned'
-            AND e.status = 'active'
+            ${hasStatus ? "AND e.status = 'active'" : ''}
             AND t.tag = ?
-          ORDER BY CASE WHEN e.confidence IS NULL THEN 0.5 ELSE e.confidence END DESC,
-                   CASE WHEN e.access_count IS NULL THEN 0 ELSE e.access_count END DESC
-          LIMIT 15
+          LIMIT 50
         `).all(projectTag).filter(entity => isTrustedForAutoContext(entity.metadata));
-
-        if (lessonEntities.length > 0) {
-          memorySummary += '\n\n⚠️ Known lessons for this project:\n';
-          for (const lesson of lessonEntities) {
-            // Load ALL observations per lesson (not fragile LIKE pattern)
-            const allObs = db.prepare(
-              'SELECT content FROM observations WHERE entity_id = ? ORDER BY id'
-            ).all(lesson.id);
-
-            // Find the Prevention line
-            const prevention = allObs.find(o => o.content.startsWith('Prevention:'));
-            const display = prevention
-              ? prevention.content.replace(/^Prevention:\s*/, '')
-              : (allObs[allObs.length - 1]?.content || lesson.name);
-
-            const conf = typeof lesson.confidence === 'number' ? lesson.confidence.toFixed(1) : '1.0';
-            memorySummary += `• ${display} (confidence: ${conf})\n`;
-          }
-        }
-      } catch {
-        // Lesson query failed — don't break session start
+        lessonCount = lessonRows.length;
+      } catch (err) {
+        // Real query bug (typo, missing column on a schema older than v2.11)
+        // — surface to stderr so a maintainer sees it on next session.
+        try { process.stderr.write(`[memesh session-start] lesson query: ${err?.message || err}\n`); } catch {}
       }
 
-      // --- Agentic-orchestration mode banner (experimental protocol, opt-in) ---
-      // memesh ships an experimental working-model protocol alongside its
-      // memory layer. The banner reminds Claude at session start that the
-      // suggested default for verifiable work (build/test/lint/migrate/
-      // refactor/benchmark) is to dispatch a background agent rather than
-      // block the conversation; strategic work stays foreground.
-      //
-      // OPT-IN ONLY: enabled via MEMESH_ENABLE_AGENTIC_ORCHESTRATION=1.
-      // The default is OFF — main wedge of memesh is local memory; the
-      // working-model protocol is a separable experiment, and its banner
-      // would otherwise dominate every session for users who never asked
-      // for it. Setting the flag also enables local skill-usage telemetry
-      // (~/.memesh/skill-usage.jsonl) so the protocol can later be
-      // validated with real usage data.
-      if (isAgenticOrchestrationEnabled(process.env)) {
-        try {
-          memorySummary +=
-            '\n\n[Experimental working model — protocol; effectiveness still being validated] ' +
-            'User=CTO · Claude=Orchestrator · Agents=Engineering team\n' +
-            'Verifiable work (build/test/lint/refactor/benchmark) → dispatch as background agent (Task with run_in_background:true).\n' +
-            'Strategic work → stay foreground. Skill: agentic-orchestration.';
+      // Build multi-line tree summary (count-based, no entity bullets)
+      const projectCount = projectEntities.length;
+      const recentCount = recentEntities.length;
+      const memoryParts = [];
+      if (projectCount > 0) {
+        memoryParts.push(`${projectCount} project memor${projectCount === 1 ? 'y' : 'ies'}`);
+      }
+      if (recentCount > 0) {
+        memoryParts.push(`${recentCount} recent memor${recentCount === 1 ? 'y' : 'ies'}`);
+      }
+      if (lessonCount > 0) {
+        memoryParts.push(`${lessonCount} active lesson${lessonCount === 1 ? '' : 's'}`);
+      }
 
-          // Local-only telemetry — never networked. Hook writes the JSONL
-          // line directly to keep itself self-contained (no dynamic import
-          // of compiled TS). Only fires when the user has opted in above.
-          try {
-            const usagePath = join(homedir(), '.memesh', 'skill-usage.jsonl');
-            // Hash the cwd so distinct-project counting still works without
-            // persisting any path fragment. SHA-256 → first 16 hex chars =
-            // 64 bits, plenty to distinguish projects on one machine.
-            const cwd = String(data?.cwd || process.cwd());
-            const cwdHashed = createHash('sha256').update(cwd).digest('hex').slice(0, 16);
-            const line = JSON.stringify({
-              ts: new Date().toISOString(),
-              event: 'agentic_orchestration_banner_injected',
-              payload: { cwd_hashed: cwdHashed },
-            }) + '\n';
-            appendFileSync(usagePath, line);
-            // Tighten mode — telemetry includes timestamps + per-project
-            // hashed cwd which can profile user activity. Other local
-            // users on a shared system should not be able to read it.
-            try { chmodSync(usagePath, 0o600); } catch { /* non-POSIX */ }
-          } catch { /* swallow — telemetry must not break session-start */ }
-        } catch {
-          // Banner failed — non-critical, continue
+      let summary;
+      if (memoryParts.length === 0) {
+        summary = `◉ MeMesh ready · no memories for "${projectName}" yet`;
+      } else {
+        const treeLines = ['◉ MeMesh memory loaded'];
+        for (let i = 0; i < memoryParts.length; i++) {
+          const branch = i === memoryParts.length - 1 ? '└─' : '├─';
+          treeLines.push(`  ${branch} ${memoryParts[i]}`);
         }
+        summary = treeLines.join('\n');
       }
 
       // --- Record injected entity IDs for recall effectiveness tracking ---
+      // The hit/miss tracker excludes entity names found in `injectedContext`
+      // from the "user referenced this memory" signal. With the new
+      // count-only summary we no longer surface names, so set the field to
+      // a sentinel so substring matching is a no-op (any entity name is a
+      // genuine hit).
       try {
-        // CRITICAL: Deduplicate by entity ID (entity may appear in both project and recent lists)
         const seenIds = new Set();
         const allInjected = [...projectEntities, ...recentEntities].filter(e => {
           if (seenIds.has(e.id)) return false;
@@ -585,7 +574,6 @@ process.stdin.on('end', async () => {
           const sessionsDir = join(memeshDir, 'sessions');
           ensurePrivateDir(sessionsDir);
 
-          // FIX: Use session-scoped file with unique ID (pid + timestamp)
           const sessionId = `${process.pid}-${Date.now()}`;
           writePrivateJson(
             join(sessionsDir, `${sessionId}.json`),
@@ -594,8 +582,7 @@ process.stdin.on('end', async () => {
               project: projectName,
               entityIds: allInjected.map(e => e.id),
               entityNames: allInjected.map(e => e.name),
-              // FIX: Save injected context text to exclude from hit detection
-              injectedContext: memorySummary,
+              injectedContext: summary,
             }
           );
 
@@ -613,15 +600,35 @@ process.stdin.on('end', async () => {
             }
           } catch {}
         }
-      } catch {
-        // Non-critical — don't break session start
+      } catch (err) {
+        // Non-critical — sessions-file write powers recall-effectiveness
+        // tracking (recall_hits / recall_misses on the dashboard). If it
+        // silently breaks, the impact-score factor in core/scoring.ts
+        // converges on 0.5 (neutral) for everything. Stderr trace so a
+        // permission/serialisation regression is visible.
+        try { process.stderr.write(`[memesh session-start] sessions-write: ${err?.message || err}\n`); } catch {}
       }
 
-      // Deprecation-aware banner. Reads the cache produced by the
-      // last `getUpdateCheck` (CLI or background refresh). When the
-      // installed version was flagged by maintainers (typically a
-      // security advisory), prepend a strong warning so the user sees
-      // it on every session start until they upgrade.
+      // --- Agentic-orchestration mode (opt-in) ---
+      // Banner kept short. Telemetry write preserved for protocol validation.
+      if (isAgenticOrchestrationEnabled(process.env)) {
+        summary += '\n[AO opt-in: dispatch verifiable work as background agent · skill: agentic-orchestration]';
+        try {
+          const usagePath = join(homedir(), '.memesh', 'skill-usage.jsonl');
+          const cwd = String(data?.cwd || process.cwd());
+          const cwdHashed = createHash('sha256').update(cwd).digest('hex').slice(0, 16);
+          const line = JSON.stringify({
+            ts: new Date().toISOString(),
+            event: 'agentic_orchestration_banner_injected',
+            payload: { cwd_hashed: cwdHashed },
+          }) + '\n';
+          appendFileSync(usagePath, line);
+          try { chmodSync(usagePath, 0o600); } catch { /* non-POSIX */ }
+        } catch { /* swallow — telemetry must not break session-start */ }
+      }
+
+      // Deprecation banner (security advisory) — surfaced even with the
+      // short summary so flagged installs still warn on every session.
       let installedVersion = null;
       try {
         const pluginRoot = resolvePluginRoot(import.meta.url);
@@ -634,11 +641,11 @@ process.stdin.on('end', async () => {
       const deprecationLines = installedVersion
         ? buildDeprecationBanner(installedVersion, updateCache)
         : [];
-      const memorySummaryWithBanner = deprecationLines.length > 0
-        ? [...deprecationLines, '', ...memorySummary.split('\n')].join('\n')
-        : memorySummary;
+      const finalMessage = deprecationLines.length > 0
+        ? [...deprecationLines.filter(l => l.length > 0), '', summary].join('\n')
+        : summary;
 
-      output(buildReferenceContext(memorySummaryWithBanner.split('\n')));
+      output(finalMessage);
     } finally {
       db.close();
     }
@@ -657,8 +664,13 @@ process.stdin.on('end', async () => {
       } finally {
         dbMod.closeDatabase();
       }
-    } catch {
-      // Non-critical — noise compression failed, will retry next session
+    } catch (err) {
+      // Non-critical — noise compression failed, will retry next session.
+      // Trace because this catch previously hid an off-by-one regression
+      // in resolvePluginRoot (4.0.4-4.1.0) that silently disabled both
+      // noise compression AND LLM failure analysis for three minor
+      // releases. A one-line stderr would have surfaced it on day 1.
+      try { process.stderr.write(`[memesh session-start] noise-compression: ${err?.message || err}\n`); } catch {}
     }
 
     } catch (err) {

--- a/scripts/hooks/session-summary.js
+++ b/scripts/hooks/session-summary.js
@@ -5,12 +5,13 @@
 // and stores as session-insight entities in MeMesh.
 
 import { createRequire } from 'module';
-import { join, basename } from 'path';
+import { basename, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { pathToFileURL } from 'url';
 import {
   decideAutoUpdateHook,
-  getMemeshDir,
+  getMemeshDirFromDbPath,
+  getProjectName,
   isAutoCaptureEnabled,
   openHookDb,
   readUpdateCheckCache,
@@ -188,13 +189,34 @@ process.stdin.on('end', async () => {
     // LLM path threw `projectName is not defined` silently — caught by
     // the LLM try/catch but logged to stderr. Result: lesson_learned
     // creation never actually happened in production.
-    const projectName = basename(cwd);
+    const projectName = getProjectName(cwd);
 
     // Open DB via shared helper — applies SCHEMA_SQL + status migration.
     // sqlite-vec is loaded separately because only this hook needs it
     // (for embedding-aware recall-effectiveness tracking).
-    const sqliteVec = require('sqlite-vec');
-    const { db } = openHookDb(process.env);
+    const handle = openHookDb(process.env);
+    if (!handle) {
+      // Native module unavailable (plugin-marketplace cache install with no
+      // node_modules). Skip session-capture work, but still let the
+      // auto-update tail below run — auto-update is a separate concern from
+      // session-capture, and a transient DB-availability blip should not
+      // mask a security-override patch upgrade. Throwing this sentinel
+      // routes through the existing catch, which already stderr-traces;
+      // execution then falls through to runAutoUpdateAtStop().
+      throw new Error('skip-session-capture: better-sqlite3 unavailable');
+    }
+    const { db } = handle;
+    // sqlite-vec is also a native module; same plugin-cache scenario applies
+    // (the cache tarball ships neither node_module). Resolve through a
+    // try/require here so a missing vec module degrades the same way as a
+    // missing better-sqlite3 instead of throwing into the outer catch as a
+    // bug-shaped error.
+    let sqliteVec;
+    try {
+      sqliteVec = require('sqlite-vec');
+    } catch {
+      throw new Error('skip-session-capture: sqlite-vec unavailable');
+    }
     try {
       sqliteVec.load(db);
 
@@ -269,7 +291,7 @@ process.stdin.on('end', async () => {
       // their names appear in the transcript, update hits/misses.
       try {
         // FIX: Find the most recent session file for this project (within last hour)
-        const sessionsDir = join(getMemeshDir(process.env), 'sessions');
+        const sessionsDir = join(getMemeshDirFromDbPath(), 'sessions');
         let injectedData = null;
 
         if (existsSync(sessionsDir)) {
@@ -281,7 +303,10 @@ process.stdin.on('end', async () => {
               try {
                 const stats = require('fs').statSync(path);
                 return { path, mtime: stats.mtimeMs };
-              } catch {
+              } catch (err) {
+                // statSync threw — file vanished between readdir and stat,
+                // or perms changed mid-scan. Skip but trace.
+                try { process.stderr.write(`[memesh session-summary] sessions-stat ${path}: ${err?.message || err}\n`); } catch {}
                 return null;
               }
             })
@@ -298,7 +323,14 @@ process.stdin.on('end', async () => {
                 require('fs').unlinkSync(path);
                 break;
               }
-            } catch {}
+            } catch (err) {
+              // Three failure modes share this catch: JSON.parse on a
+              // corrupt session file, readFileSync on a perm-changed file,
+              // unlinkSync after read. Trace each so a silent unlink
+              // failure (which would re-count the same session) is
+              // visible. Loop continues to the next file regardless.
+              try { process.stderr.write(`[memesh session-summary] sessions-read ${path}: ${err?.message || err}\n`); } catch {}
+            }
           }
         }
 
@@ -339,8 +371,13 @@ process.stdin.on('end', async () => {
             }
           }
         }
-      } catch {
-        // Non-critical — don't break session summary
+      } catch (err) {
+        // Recall-effectiveness DB write failed. Silently dropping this
+        // converges impact scores to 0.5 (neutral) for every entity, which
+        // is the main signal core/scoring.ts uses to demote ignored
+        // memories — a real-world UX issue. Trace to stderr so a typo or
+        // missing-column failure is visible without crashing the hook.
+        try { process.stderr.write(`[memesh session-summary] recall-effectiveness write: ${err?.message || err}\n`); } catch {}
       }
     } finally {
       db.close();
@@ -380,8 +417,13 @@ process.stdin.on('end', async () => {
       }
     }
   } catch (err) {
-    // Never crash Claude Code — leave a trace for debugging
-    try { process.stderr.write(`[memesh session-summary] ${err?.message || err}\n`); } catch {}
+    // Never crash Claude Code — leave a trace for debugging.
+    // Suppress the expected "skip-session-capture" sentinel (raised when
+    // better-sqlite3 is unavailable in a marketplace-cache install). All
+    // other errors are real bugs and deserve a trace.
+    if (!String(err?.message || '').startsWith('skip-session-capture:')) {
+      try { process.stderr.write(`[memesh session-summary] ${err?.message || err}\n`); } catch {}
+    }
   }
 
   // Spawn auto-update if policy + cache permit. Runs after all session work

--- a/src/cli/view.ts
+++ b/src/cli/view.ts
@@ -3,9 +3,9 @@
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { execFile } from 'child_process';
 import { fileURLToPath } from 'url';
+import { getDbPath, memeshDir } from '../core/paths.js';
 
 interface DashboardData {
   entities: Array<{
@@ -202,10 +202,7 @@ function escapeJsonForHtml(json: string): string {
  * Opens the database read-only and queries all data.
  */
 export function generateDashboardHtml(dbPath?: string): string {
-  const resolvedPath =
-    dbPath ??
-    process.env.MEMESH_DB_PATH ??
-    path.join(os.homedir(), '.memesh', 'knowledge-graph.db');
+  const resolvedPath = dbPath ?? getDbPath();
 
   const data = queryData(resolvedPath);
   const dataJson = escapeJsonForHtml(JSON.stringify(data));
@@ -563,12 +560,10 @@ const isDirectRun =
   fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
 
 if (isDirectRun) {
-  const dbPath =
-    process.env.MEMESH_DB_PATH ??
-    path.join(os.homedir(), '.memesh', 'knowledge-graph.db');
+  const dbPath = getDbPath();
 
   const html = generateDashboardHtml(dbPath);
-  const dashboardDir = path.join(os.homedir(), '.memesh');
+  const dashboardDir = memeshDir();
   fs.mkdirSync(dashboardDir, { recursive: true });
   const outPath = path.join(dashboardDir, 'dashboard.html');
   fs.writeFileSync(outPath, html, { encoding: 'utf-8', mode: 0o600 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { createRequire } from 'module';
+import { memeshDir } from './paths.js';
 
 // --- Config Types ---
 
@@ -74,33 +74,47 @@ export interface Capabilities {
 }
 
 // --- Config File Path ---
-
-const CONFIG_DIR = path.join(os.homedir(), '.memesh');
-const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+//
+// Resolved lazily via `memeshDir()` so HOME-first override (used by hermetic
+// Windows tests that point HOME at a tmpdir) takes effect on every read /
+// write — the previous module-load-time constants captured the pre-test
+// HOME value, defeating isolation. See src/core/paths.ts for the precedence
+// rules (MEMESH_DIR > <home>/.memesh).
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
+
+function configDir(): string {
+  return memeshDir();
+}
+
+function configFilePath(): string {
+  return path.join(configDir(), 'config.json');
+}
 
 // --- Read/Write ---
 
 export function readConfig(): MeMeshConfig {
   try {
-    if (!fs.existsSync(CONFIG_PATH)) return {};
-    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const p = configFilePath();
+    if (!fs.existsSync(p)) return {};
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
   } catch {
     return {};
   }
 }
 
 export function writeConfig(config: MeMeshConfig): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: PRIVATE_DIR_MODE });
+  const dir = configDir();
+  const p = configFilePath();
+  fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
   try {
-    fs.chmodSync(CONFIG_DIR, PRIVATE_DIR_MODE);
+    fs.chmodSync(dir, PRIVATE_DIR_MODE);
   } catch {
     // Best-effort hardening only.
   }
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: PRIVATE_FILE_MODE });
+  fs.writeFileSync(p, JSON.stringify(config, null, 2), { mode: PRIVATE_FILE_MODE });
   try {
-    fs.chmodSync(CONFIG_PATH, PRIVATE_FILE_MODE);
+    fs.chmodSync(p, PRIVATE_FILE_MODE);
   } catch {
     // Best-effort hardening only.
   }
@@ -266,5 +280,5 @@ export function logCapabilities(config?: MeMeshConfig): void {
 
 // --- Config Path Exports (for testing) ---
 
-export function getConfigDir(): string { return CONFIG_DIR; }
-export function getConfigPath(): string { return CONFIG_PATH; }
+export function getConfigDir(): string { return configDir(); }
+export function getConfigPath(): string { return configFilePath(); }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { createHash } from 'crypto';
 import { detectCapabilities, getConfigPath } from './config.js';
@@ -7,6 +6,7 @@ import { openDatabase, closeDatabase, getPendingReindexInfo, isDatabaseOpen } fr
 import { getUpdateCheck } from './version-check.js';
 import { getCurrentInstallChannel, getInstallChannelSupport } from './install-channel.js';
 import { getInstallRecord } from './install-id.js';
+import { getDbPath, memeshDir } from './paths.js';
 
 export type DoctorCheckStatus = 'pass' | 'warn' | 'fail';
 export type DoctorOverallStatus = 'PASS' | 'PASS_WITH_CONCERNS' | 'FAIL';
@@ -55,7 +55,7 @@ interface DoctorOptions {
 const EXPECTED_HOOK_TYPES = ['PreToolUse', 'SessionStart', 'PostToolUse', 'Stop', 'PreCompact'];
 
 function resolveDatabasePath(): string {
-  return process.env.MEMESH_DB_PATH ?? path.join(os.homedir(), '.memesh', 'knowledge-graph.db');
+  return getDbPath();
 }
 
 function createCheck(
@@ -893,8 +893,7 @@ export async function runDoctor(options: DoctorOptions): Promise<DoctorResult> {
   // Runtime wiring + activity (#25 — file existence isn't enough;
   // doctor used to PASS for users whose Claude Code never loaded
   // memesh's hooks at all).
-  const memeshDir = process.env.MEMESH_DIR ?? path.join(os.homedir(), '.memesh');
-  checks.push(inspectHookWiring(existsSyncImpl, readFileSyncImpl, memeshDir));
+  checks.push(inspectHookWiring(existsSyncImpl, readFileSyncImpl, memeshDir()));
   checks.push(inspectHookActivity(openDatabaseImpl, safeCloseDatabaseImpl));
   checks.push(inspectDashboardArtifact(packageRoot, existsSyncImpl));
   checks.push(verifySkillsManifest(packageRoot, existsSyncImpl, readFileSyncImpl));

--- a/src/core/embedder.ts
+++ b/src/core/embedder.ts
@@ -7,9 +7,9 @@
 
 import { createRequire } from 'node:module';
 import { getDatabase } from '../db.js';
-import { homedir } from 'os';
 import { join } from 'path';
 import { detectCapabilities, type LLMConfig } from './config.js';
+import { memeshDir } from './paths.js';
 
 let onnxPipelineInstance: any = null;
 let onnxPipelineLoading: Promise<any> | null = null;
@@ -277,7 +277,7 @@ async function getOnnxPipeline(): Promise<any> {
       const createPipeline = mod.pipeline;
       const env = mod.env;
       if (env) {
-        env.cacheDir = join(homedir(), '.memesh', 'models');
+        env.cacheDir = join(memeshDir(), 'models');
         env.allowLocalModels = true;
       }
       onnxPipelineInstance = await createPipeline(

--- a/src/core/extractor.ts
+++ b/src/core/extractor.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { getProjectName } from './paths.js';
 
 // =============================================================================
 // Extractor Interface (pluggable — rule-based now, LLM-based later)
@@ -154,7 +155,7 @@ export function parseTranscript(transcriptPath: string): {
 export class RuleBasedExtractor implements Extractor {
   extract(context: SessionContext): ExtractedMemory[] {
     const memories: ExtractedMemory[] = [];
-    const projectName = path.basename(context.cwd);
+    const projectName = getProjectName(context.cwd);
     const sessionTag = `session:${context.sessionId}`;
     const baseTags = ['source:auto-capture', sessionTag, `project:${projectName}`];
 

--- a/src/core/install-hooks.ts
+++ b/src/core/install-hooks.ts
@@ -35,8 +35,8 @@
 // blocking — users with their own hooks should know they coexist.
 
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
+import { homeDir, memeshDir } from './paths.js';
 
 type HookCommand = { type: 'command'; command: string; timeout?: number; _memesh?: boolean };
 type HookEntry = { matcher?: string; hooks: HookCommand[] };
@@ -78,20 +78,10 @@ export interface UninstallResult {
 
 const MARKER_FILE = 'install-hooks.json';
 
-// On Windows, os.homedir() reads from the GetUserProfileDirectoryW Win32
-// API and ignores both USERPROFILE and HOME env vars. That makes tests
-// unable to redirect home-dir lookups to a tmp dir for hermetic runs.
-// We accept HOME as a higher-priority override on all platforms so tests
-// (and any users who deliberately set HOME on Windows for compatibility)
-// can isolate filesystem operations. Production users on Windows almost
-// never set HOME, so this falls through to os.homedir() as before.
-function homeDir(): string {
-  return process.env.HOME ?? os.homedir();
-}
-
-function memeshDir(): string {
-  return process.env.MEMESH_DIR ?? path.join(homeDir(), '.memesh');
-}
+// homeDir() and memeshDir() now live in src/core/paths.ts as the single
+// canonical source. Imported above. Earlier this file had private copies;
+// the reasoning (HOME-first for hermetic tests on Windows) is preserved
+// in the JSDoc on `homeDir()` in paths.ts.
 
 function settingsPathFor(scope: 'user' | 'project', cwd: string): string {
   if (scope === 'project') {

--- a/src/core/install-id.ts
+++ b/src/core/install-id.ts
@@ -19,9 +19,9 @@
 // is helpful for support; never add anything that maps to a person).
 
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { randomUUID } from 'crypto';
+import { memeshDir } from './paths.js';
 
 interface InstallRecord {
   install_id: string;
@@ -32,8 +32,7 @@ interface InstallRecord {
 const SCHEMA_VERSION = 1 as const;
 
 function installFilePath(): string {
-  const dir = process.env.MEMESH_DIR ?? path.join(os.homedir(), '.memesh');
-  return path.join(dir, 'install.json');
+  return path.join(memeshDir(), 'install.json');
 }
 
 /**

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -13,6 +13,7 @@ import { getDatabase, clearPendingReindexFlag } from '../db.js';
 import { KnowledgeGraph } from '../knowledge-graph.js';
 import { expandQuery, isExpansionAvailable } from './query-expander.js';
 import { rankEntities } from './scoring.js';
+import { getProjectName } from './paths.js';
 import { createExplicitLesson } from './lesson-engine.js';
 import { embedAndStore, isEmbeddingAvailable, embedText, scheduleEmbedAndStore, vectorSearch } from './embedder.js';
 import { autoTagAndApply } from './auto-tagger.js';
@@ -300,7 +301,7 @@ export { exportMemories, importMemories } from './serializer.js';
  * Uses createExplicitLesson from lesson-engine to build and store the entity.
  */
 export function learn(args: LearnInput): LearnResult {
-  const projectName = path.basename(process.cwd());
+  const projectName = getProjectName();
 
   const result = createExplicitLesson(
     args.error,

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,0 +1,88 @@
+// Centralised filesystem-path resolution for memesh.
+//
+// Before this module existed, `process.env.MEMESH_DB_PATH ?? path.join(...)`
+// was inlined in 8+ core sites and the HOME-first override (needed for
+// hermetic Windows tests) was applied in only 2 of them. Each site
+// resolved roughly the same path with subtle differences (`??` vs `||`,
+// with/without HOME-first), making path-related drift a recurring source
+// of audit findings.
+//
+// Hooks cannot import from `dist/` (the F5 security boundary — `dist/`
+// may be stale or absent at hook execution time), so `scripts/hooks/_shared.js`
+// keeps a mirror of these helpers. Any change to the shapes here MUST be
+// reflected in `_shared.js`. The `check-schema-drift` build-time guard
+// (`scripts/check-schema-drift.mjs`) catches the SQL portion; the path
+// helpers are short enough that a JSDoc cross-link is enough.
+
+import os from 'os';
+import path from 'path';
+
+/**
+ * Resolve the user's home directory, honouring `HOME` first.
+ *
+ * On POSIX, `os.homedir()` already consults `HOME`. On Windows it ignores
+ * env vars and reads `GetUserProfileDirectoryW` directly, which makes
+ * tests unable to redirect home-dir lookups to a tmp dir. Honouring `HOME`
+ * first lets tests set `HOME=<tmpdir>` and have it actually take effect
+ * across platforms. Production users on Windows almost never set `HOME`,
+ * so this falls through to `os.homedir()` unchanged.
+ */
+export function homeDir(): string {
+  return process.env.HOME ?? os.homedir();
+}
+
+/**
+ * Resolve the memesh data directory.
+ *
+ * Precedence: `MEMESH_DIR` env var > `<home>/.memesh`. Note that
+ * `MEMESH_DB_PATH` (the more granular override, used when the user wants
+ * the DB file at a non-default location) is NOT consulted here — see
+ * `getDbPath()` for that. Callers that need the directory containing the
+ * active DB file should use `getMemeshDirFromDbPath()` instead.
+ */
+export function memeshDir(): string {
+  return process.env.MEMESH_DIR ?? path.join(homeDir(), '.memesh');
+}
+
+/**
+ * Resolve the active memesh DB path.
+ *
+ * Precedence: `MEMESH_DB_PATH` env var > `<memeshDir()>/knowledge-graph.db`.
+ * Most callers want this rather than a hand-rolled `process.env.MEMESH_DB_PATH ?? ...`,
+ * so they automatically inherit the HOME-first override on Windows tests.
+ */
+export function getDbPath(): string {
+  return process.env.MEMESH_DB_PATH ?? path.join(memeshDir(), 'knowledge-graph.db');
+}
+
+/**
+ * Resolve the directory containing the active DB file.
+ *
+ * When `MEMESH_DB_PATH` is set, returns its parent directory. Otherwise
+ * returns `memeshDir()`. Use this when you need to write sibling files
+ * next to the DB (e.g. session tracking, update-check cache) rather than
+ * the global memesh dir.
+ */
+export function getMemeshDirFromDbPath(): string {
+  return process.env.MEMESH_DB_PATH
+    ? path.dirname(process.env.MEMESH_DB_PATH)
+    : memeshDir();
+}
+
+/**
+ * Derive the project name from a working directory.
+ *
+ * Five hooks and two core operations all derived this with subtly
+ * different fallback chains:
+ *   - hooks: `basename(data.cwd || process.cwd())`
+ *   - core/operations: `basename(process.cwd())`
+ *   - core/extractor: `basename(context.cwd)` (no fallback)
+ *
+ * This unified version takes an optional explicit cwd (e.g. from a hook
+ * payload) and falls through to `process.cwd()`. Empty / missing inputs
+ * also fall through, matching the most permissive caller's behaviour.
+ */
+export function getProjectName(cwdInput?: string | null): string {
+  const cwd = cwdInput && cwdInput.length > 0 ? cwdInput : process.cwd();
+  return path.basename(cwd);
+}

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -20,6 +20,29 @@ export const DEFAULT_WEIGHTS: ScoringWeights = {
 };
 
 /**
+ * Weights as used by `scripts/hooks/session-start.js` SQL ORDER BY.
+ *
+ * Session-start ranks the project's auto-context entities in pure SQL
+ * (no FTS query → no searchRelevance, and impact is folded into core's
+ * ranking pass instead). The three remaining factors (recency, frequency,
+ * confidence) are renormalised so they sum to 1.0 and preserve the
+ * proportions of `DEFAULT_WEIGHTS`.
+ *
+ * If you change `DEFAULT_WEIGHTS`, recompute these and update the SQL in
+ * `session-start.js` to match (the `0.4167 / 0.3000 / 0.2833` magic
+ * numbers in the ORDER BY clause). The values are exported here so a
+ * future test (or eslint rule) can assert the SQL stays in sync.
+ */
+export const SESSION_START_WEIGHT_RATIO = (() => {
+  const sub = DEFAULT_WEIGHTS.recency + DEFAULT_WEIGHTS.frequency + DEFAULT_WEIGHTS.confidence;
+  return {
+    recency: DEFAULT_WEIGHTS.recency / sub,
+    frequency: DEFAULT_WEIGHTS.frequency / sub,
+    confidence: DEFAULT_WEIGHTS.confidence / sub,
+  };
+})();
+
+/**
  * Calculate recency score using exponential decay.
  * Score = e^(-days_since_access / 30)
  * Recent = 1.0, 30 days = 0.37, 60 days = 0.14, 90 days = 0.05

--- a/src/core/skill-usage-log.ts
+++ b/src/core/skill-usage-log.ts
@@ -50,14 +50,14 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'fs';
-import { homedir } from 'os';
 import { dirname, join } from 'path';
+import { memeshDir } from './paths.js';
 
 const MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 const TRUNCATE_KEEP = 6 * 1024 * 1024; // keep last 6 MB after truncation
 
 function defaultLogPath(): string {
-  return join(homedir(), '.memesh', 'skill-usage.jsonl');
+  return join(memeshDir(), 'skill-usage.jsonl');
 }
 
 function ensureParent(path: string): void {

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { execFile } from 'child_process';
+import { memeshDir } from './paths.js';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
@@ -72,7 +72,7 @@ function getUpdateCheckPath(
   const versionTag = currentVersion && /^[0-9A-Za-z.+-]+$/.test(currentVersion)
     ? currentVersion
     : 'unknown';
-  return path.join(os.homedir(), '.memesh', `update-check.${versionTag}.json`);
+  return path.join(memeshDir(), `update-check.${versionTag}.json`);
 }
 
 function parseIsoDate(value: string | null): number | null {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,11 +1,11 @@
 import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 import path from 'path';
-import os from 'os';
 import fs from 'fs';
 import { runAutoDecay } from './core/lifecycle.js';
 import { getEmbeddingDimension } from './core/config.js';
 import { computeSignalScore } from './core/signal-scorer.js';
+import { getDbPath } from './core/paths.js';
 import type { PragmaColumnRow } from './core/types.js';
 
 let db: Database.Database | null = null;
@@ -70,9 +70,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
 export function openDatabase(dbPath?: string): Database.Database {
   if (db) return db;
 
-  const resolvedPath = dbPath
-    ?? process.env.MEMESH_DB_PATH
-    ?? path.join(os.homedir(), '.memesh', 'knowledge-graph.db');
+  const resolvedPath = dbPath ?? getDbPath();
 
   const dir = path.dirname(resolvedPath);
   fs.mkdirSync(dir, { recursive: true });

--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -5,7 +5,6 @@ import type { Request, Response, NextFunction } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import { z } from 'zod';
 import { randomBytes, timingSafeEqual } from 'crypto';
-import { homedir } from 'os';
 import { openDatabase, closeDatabase, getDatabase } from '../../db.js';
 import { remember, recallEnhanced, forget, consolidate, exportMemories, importMemories, learn } from '../../core/operations.js';
 import { KnowledgeGraph } from '../../knowledge-graph.js';
@@ -25,6 +24,7 @@ import {
 } from '../schemas.js';
 import { getUpdateCheck } from '../../core/version-check.js';
 import { getCurrentInstallChannel, getInstallChannelSupport } from '../../core/install-channel.js';
+import { getDbPath, getMemeshDirFromDbPath } from '../../core/paths.js';
 
 import fs from 'fs';
 import path from 'path';
@@ -74,9 +74,7 @@ let remoteToken: Buffer | null = null;
 const serverAuthRequired = new WeakMap<import('http').Server, boolean>();
 
 function memeshDir(): string {
-  return process.env.MEMESH_DB_PATH
-    ? path.dirname(process.env.MEMESH_DB_PATH)
-    : path.join(homedir(), '.memesh');
+  return getMemeshDirFromDbPath();
 }
 
 function loadOrCreateRemoteToken(): { token: Buffer; freshlyCreated: boolean } {
@@ -726,7 +724,7 @@ export function startServer(
     db.prepare('SELECT COUNT(*) FROM entities').get();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const dbPath = process.env.MEMESH_DB_PATH || path.join(homedir(), '.memesh', 'knowledge-graph.db');
+    const dbPath = getDbPath();
     console.error('\n❌ MeMesh startup failed: database cannot be opened\n');
     console.error(`   Database path: ${dbPath}`);
     console.error(`   Error: ${message}\n`);

--- a/tests/core/scoring.test.ts
+++ b/tests/core/scoring.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { recencyScore, frequencyScore, impactScore, rankEntities } from '../../src/core/scoring.js';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  recencyScore,
+  frequencyScore,
+  impactScore,
+  rankEntities,
+  SESSION_START_WEIGHT_RATIO,
+  DEFAULT_WEIGHTS,
+} from '../../src/core/scoring.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('Scoring Engine', () => {
   describe('recencyScore', () => {
@@ -81,6 +93,40 @@ describe('Scoring Engine', () => {
       const relevance = new Map([['old', 0.5], ['recent', 0.5]]);
       const ranked = rankEntities(entities, relevance);
       expect(ranked[0].name).toBe('recent');
+    });
+  });
+
+  describe('SESSION_START_WEIGHT_RATIO', () => {
+    it('renormalises recency/frequency/confidence to sum to 1.0', () => {
+      const sum = SESSION_START_WEIGHT_RATIO.recency
+        + SESSION_START_WEIGHT_RATIO.frequency
+        + SESSION_START_WEIGHT_RATIO.confidence;
+      expect(sum).toBeCloseTo(1.0, 6);
+    });
+
+    it('preserves the proportions of DEFAULT_WEIGHTS', () => {
+      const subTotal = DEFAULT_WEIGHTS.recency + DEFAULT_WEIGHTS.frequency + DEFAULT_WEIGHTS.confidence;
+      expect(SESSION_START_WEIGHT_RATIO.recency).toBeCloseTo(DEFAULT_WEIGHTS.recency / subTotal, 6);
+      expect(SESSION_START_WEIGHT_RATIO.frequency).toBeCloseTo(DEFAULT_WEIGHTS.frequency / subTotal, 6);
+      expect(SESSION_START_WEIGHT_RATIO.confidence).toBeCloseTo(DEFAULT_WEIGHTS.confidence / subTotal, 6);
+    });
+
+    // Drift guard: the session-start hook hard-codes these weights inside a
+    // SQL ORDER BY string (no module imports cross the F5 boundary). If
+    // DEFAULT_WEIGHTS changes the ratios, the hook SQL must be updated
+    // too. This test fails loudly so a maintainer cannot silently shift
+    // session-start ranking out of sync with core ranking.
+    it('matches the hard-coded magic numbers in scripts/hooks/session-start.js', () => {
+      const hookSrc = readFileSync(
+        resolve(__dirname, '../../scripts/hooks/session-start.js'),
+        'utf8',
+      );
+      const recencyStr = SESSION_START_WEIGHT_RATIO.recency.toFixed(4);
+      const frequencyStr = SESSION_START_WEIGHT_RATIO.frequency.toFixed(4);
+      const confidenceStr = SESSION_START_WEIGHT_RATIO.confidence.toFixed(4);
+      expect(hookSrc).toContain(`* ${recencyStr}`);
+      expect(hookSrc).toContain(`* ${frequencyStr}`);
+      expect(hookSrc).toContain(`* ${confidenceStr}`);
     });
   });
 });

--- a/tests/hooks/pre-bash-orchestration-nudge.test.ts
+++ b/tests/hooks/pre-bash-orchestration-nudge.test.ts
@@ -13,7 +13,7 @@ describe('Feature: Pre-Bash Orchestration Nudge Hook', () => {
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-nudge-test-'));
     // We set MEMESH_DB_PATH to a file inside testDir; the hook derives memeshDir
-    // from dirname(MEMESH_DB_PATH), matching getMemeshDir() in _shared.js
+    // from dirname(MEMESH_DB_PATH), matching getMemeshDirFromDbPath() in _shared.js
     memeshDir = testDir;
     flagsDir = path.join(memeshDir, 'agent-nudge-flags');
   });

--- a/tests/hooks/session-start-telemetry.test.ts
+++ b/tests/hooks/session-start-telemetry.test.ts
@@ -62,10 +62,13 @@ describe('session-start hook: agentic-orchestration telemetry', () => {
     );
 
     expect(exitCode).toBe(0);
-    // Banner text must appear in additionalContext (regression: tone-down
-    // wording must contain "Experimental working model" so users see the
-    // "validation in progress" framing).
-    expect(stdout).toContain('Experimental working model');
+    // Banner text must appear in additionalContext. The new compact tree
+    // summary surfaces the protocol via a single tagged line ("[AO opt-in:
+    // ... skill: agentic-orchestration]") instead of the old multi-line
+    // banner — both shapes pin the user-visible signal that the protocol
+    // is active.
+    expect(stdout).toContain('agentic-orchestration');
+    expect(stdout).toContain('AO opt-in');
 
     // Telemetry file must exist with exactly one banner-injection event.
     const logPath = path.join(tmpHome, '.memesh', 'skill-usage.jsonl');
@@ -123,7 +126,8 @@ describe('session-start hook: agentic-orchestration telemetry', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(stdout).not.toContain('Experimental working model');
+    expect(stdout).not.toContain('AO opt-in');
+    expect(stdout).not.toContain('agentic-orchestration');
 
     const logPath = path.join(tmpHome, '.memesh', 'skill-usage.jsonl');
     expect(fs.existsSync(logPath)).toBe(false);

--- a/tests/hooks/session-start.test.ts
+++ b/tests/hooks/session-start.test.ts
@@ -11,10 +11,12 @@ const require = createRequire(import.meta.url);
 describe('Feature: Session Start Hook', () => {
   let testDir: string;
   let dbPath: string;
+  let sessionsDir: string;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-hook-test-'));
     dbPath = path.join(testDir, 'test.db');
+    sessionsDir = path.join(testDir, 'sessions');
   });
 
   afterEach(() => {
@@ -31,6 +33,26 @@ describe('Feature: Session Start Hook', () => {
       timeout: 15000,
     });
     return JSON.parse(result.trim());
+  }
+
+  // Tests that need to assert which specific entities were loaded read the
+  // sessions/{pid}-{ts}.json file the hook persists for hit/miss tracking.
+  // The user-visible summary is a count-only tree and intentionally does
+  // not surface entity names.
+  function readLatestSessionFile(): {
+    project: string;
+    entityIds: number[];
+    entityNames: string[];
+    injectedContext: string;
+  } | null {
+    if (!fs.existsSync(sessionsDir)) return null;
+    const files = fs
+      .readdirSync(sessionsDir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => ({ f, mtime: fs.statSync(path.join(sessionsDir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    if (files.length === 0) return null;
+    return JSON.parse(fs.readFileSync(path.join(sessionsDir, files[0].f), 'utf8'));
   }
 
   function createTestDb(): InstanceType<typeof import('better-sqlite3')> {
@@ -82,9 +104,11 @@ describe('Feature: Session Start Hook', () => {
     return db;
   }
 
-  it('Scenario: No database exists -> welcome message', () => {
+  it('Scenario: No database exists -> tree-style welcome message', () => {
     const output = runHook({ cwd: '/tmp/myproject' });
-    expect(output.systemMessage as string).toContain('No database found');
+    const msg = output.systemMessage as string;
+    expect(msg).toContain('◉ MeMesh ready');
+    expect(msg).toContain('no database yet');
   });
 
   it('Scenario: No database + flagged installed version -> deprecation banner emits before welcome', () => {
@@ -123,7 +147,7 @@ describe('Feature: Session Start Hook', () => {
     const messages = lines.map((l) => (l as { systemMessage?: string }).systemMessage ?? '');
     expect(messages.some((m) => m.includes('DEPRECATED'))).toBe(true);
     expect(messages.some((m) => m.includes('TEST: live-test deprecation banner verification'))).toBe(true);
-    expect(messages.some((m) => m.includes('No database found'))).toBe(true);
+    expect(messages.some((m) => m.includes('◉ MeMesh ready'))).toBe(true);
     // Codex round 36: even when latestVersion === currentVersion in
     // the cache (no upgrade target apparent), the banner must
     // include a remediation line. Previously the gate was
@@ -146,7 +170,7 @@ describe('Feature: Session Start Hook', () => {
     expect(output.systemMessage).toBeTruthy();
   });
 
-  it('Scenario: Database with project memories -> recalls them in concise summary format', () => {
+  it('Scenario: Database with project memories -> tree summary with project branch', () => {
     const db = createTestDb();
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('auth-module', 'component');
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'Handles JWT token validation');
@@ -155,46 +179,49 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/myproject' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('Treat the content below as background data');
-    expect(additionalContext).toContain('Project "myproject" memories');
-    // New concise format: "• name (type): first observation"
-    expect(additionalContext).toContain('• auth-module (component)');
-    // Shows first observation (not all)
-    expect(additionalContext).toContain('Handles JWT token validation');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toContain('◉ MeMesh memory loaded');
+    expect(msg).toMatch(/[├└]─ 1 project memory/);
+    // Verbose entity bullets and observation content stay out of the summary
+    expect(msg).not.toContain('• auth-module');
+    expect(msg).not.toContain('Handles JWT token validation');
+    // Entity is still tracked for hit/miss instrumentation
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('auth-module');
   });
 
-  it('Scenario: Database with no matching project -> shows only recent memories', () => {
+  it('Scenario: Database with no matching project -> tree shows recent branch only', () => {
     const db = createTestDb();
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('some-entity', 'note');
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'A note about something');
     db.close();
 
     const output = runHook({ cwd: '/tmp/other-project' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).not.toContain('Project "other-project" memories');
-    expect(additionalContext).toContain('Recent memories');
-    expect(additionalContext).toContain('• some-entity (note)');
-    expect(additionalContext).toContain('A note about something');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toContain('◉ MeMesh memory loaded');
+    expect(msg).toMatch(/[├└]─ 1 recent memory/);
+    expect(msg).not.toMatch(/\d+ project memor/);
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('some-entity');
   });
 
-  it('Scenario: Database with both project and global memories -> shows both', () => {
+  it('Scenario: Database with both project and global memories -> tree shows both branches', () => {
     const db = createTestDb();
-    // Project entity
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('project-item', 'feature');
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'Project specific');
     db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(1, 'project:testproj');
-    // Global entity (no project tag)
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('global-item', 'note');
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(2, 'Global note');
     db.close();
 
     const output = runHook({ cwd: '/tmp/testproj' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('Project "testproj" memories');
-    expect(additionalContext).toContain('• project-item (feature)');
-    expect(additionalContext).toContain('Recent memories');
-    expect(additionalContext).toContain('• global-item (note)');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toContain('◉ MeMesh memory loaded');
+    expect(msg).toMatch(/├─ 1 project memory/);
+    expect(msg).toMatch(/[├└]─ \d+ recent memor/);
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('project-item');
+    expect(session?.entityNames).toContain('global-item');
   });
 
   it('Scenario: Imported or untrusted memories are excluded from session auto-context', () => {
@@ -209,11 +236,10 @@ describe('Feature: Session Start Hook', () => {
     db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(2, 'project:trusttest');
     db.close();
 
-    const output = runHook({ cwd: '/tmp/trusttest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('trusted-memory');
-    expect(additionalContext).not.toContain('imported-memory');
-    expect(additionalContext).not.toContain('Ignore repository policy');
+    runHook({ cwd: '/tmp/trusttest' });
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('trusted-memory');
+    expect(session?.entityNames).not.toContain('imported-memory');
   });
 
   it('Scenario: Archived entities are excluded from session recall', () => {
@@ -237,11 +263,11 @@ describe('Feature: Session Start Hook', () => {
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(3, 'Archived global');
     db.close();
 
-    const output = runHook({ cwd: '/tmp/archivetest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('• active-module (component)');
-    expect(additionalContext).not.toContain('archived-module');
-    expect(additionalContext).not.toContain('archived-global');
+    runHook({ cwd: '/tmp/archivetest' });
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('active-module');
+    expect(session?.entityNames).not.toContain('archived-module');
+    expect(session?.entityNames).not.toContain('archived-global');
   });
 
   it('Scenario: Backward compat — DBs without status column return all entities', () => {
@@ -252,9 +278,11 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/anyproject' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('• legacy-entity (note)');
-    expect(additionalContext).toContain('Legacy note');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toContain('◉ MeMesh memory loaded');
+    expect(msg).toMatch(/[├└]─ \d+ recent memor/);
+    const session = readLatestSessionFile();
+    expect(session?.entityNames).toContain('legacy-entity');
   });
 
   it('Scenario: Always exits with valid JSON output on invalid input', () => {
@@ -295,43 +323,34 @@ describe('Feature: Session Start Hook', () => {
 
     runHook({ cwd: '/tmp/permtest' });
 
-    const sessionsDir = path.join(testDir, 'sessions');
     const [sessionFile] = fs.readdirSync(sessionsDir).filter((file) => file.endsWith('.json'));
     expect(sessionFile).toBeTruthy();
     expectPrivateDir(sessionsDir);
     expectPrivateFile(path.join(sessionsDir, sessionFile));
   });
 
-  it('Scenario: Scoring — top entities by score are listed first', () => {
+  it('Scenario: Scoring — top entities by score appear first in the persisted entityNames list', () => {
     const db = createScoringDb();
-    // Low-score entity (never accessed, low confidence)
     db.prepare("INSERT INTO entities (name, type, access_count, confidence) VALUES (?, ?, ?, ?)")
       .run('low-score-entity', 'note', 0, 0.1);
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'Rarely accessed');
     db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(1, 'project:scoretest');
-    // High-score entity (frequently accessed, high confidence, recently accessed)
     db.prepare("INSERT INTO entities (name, type, access_count, last_accessed_at, confidence) VALUES (?, ?, ?, datetime('now'), ?)")
       .run('high-score-entity', 'component', 50, 1.0);
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(2, 'Frequently accessed');
     db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(2, 'project:scoretest');
     db.close();
 
-    const output = runHook({ cwd: '/tmp/scoretest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    // Both should appear
-    expect(additionalContext).toContain('• high-score-entity (component)');
-    expect(additionalContext).toContain('• low-score-entity (note)');
-    // High-score entity should appear before low-score entity
-    const highIdx = additionalContext.indexOf('high-score-entity');
-    const lowIdx = additionalContext.indexOf('low-score-entity');
-    expect(highIdx).toBeLessThan(lowIdx);
-    // Summary label should mention "by relevance"
-    expect(additionalContext).toContain('by relevance');
+    runHook({ cwd: '/tmp/scoretest' });
+    const session = readLatestSessionFile();
+    const names = session?.entityNames ?? [];
+    expect(names).toContain('high-score-entity');
+    expect(names).toContain('low-score-entity');
+    expect(names.indexOf('high-score-entity')).toBeLessThan(names.indexOf('low-score-entity'));
   });
 
-  it('Scenario: MEMESH_SESSION_LIMIT is respected', () => {
+  it('Scenario: MEMESH_SESSION_LIMIT is respected — tree shows clamped count', () => {
     const db = createScoringDb();
-    // Insert 20 entities all tagged to the same project
     for (let i = 1; i <= 20; i++) {
       db.prepare("INSERT INTO entities (name, type, access_count, confidence) VALUES (?, ?, ?, ?)")
         .run(`entity-${i}`, 'note', i, 1.0);
@@ -341,33 +360,31 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/limittest' }, { MEMESH_SESSION_LIMIT: '5' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    // Count bullet points in the project section (before "Recent memories")
-    const projectSection = additionalContext.split('\n\nRecent memories:')[0];
-    const bulletCount = (projectSection.match(/^•/gm) || []).length;
-    expect(bulletCount).toBe(5);
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toMatch(/├─ 5 project memories/);
+    const session = readLatestSessionFile();
+    const projectNames = (session?.entityNames ?? []).filter((n) => n.startsWith('entity-'));
+    expect(projectNames.length).toBe(5);
   });
 
-  it('Scenario: Concise summary format — bullet with name, type, and first observation', () => {
+  it('Scenario: Tree summary suppresses raw observation content and entity bullets', () => {
     const db = createTestDb();
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('my-service', 'service');
-    // Multiple observations — only first should appear
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'Handles authentication');
     db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(1, 'Second observation not shown');
     db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(1, 'project:formattest');
     db.close();
 
     const output = runHook({ cwd: '/tmp/formattest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    // Bullet format with name (type): observation
-    expect(additionalContext).toContain('• my-service (service): Handles authentication');
-    // Second observation should NOT appear
-    expect(additionalContext).not.toContain('Second observation not shown');
-    // Old bracket format should NOT appear
-    expect(additionalContext).not.toContain('[service] my-service');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toContain('◉ MeMesh memory loaded');
+    expect(msg).toMatch(/[├└]─ 1 project memory/);
+    expect(msg).not.toContain('• my-service');
+    expect(msg).not.toContain('Handles authentication');
+    expect(msg).not.toContain('Second observation not shown');
   });
 
-  it('Scenario: Long observation is truncated to 100 chars', () => {
+  it('Scenario: Long observation content is never displayed in the tree summary', () => {
     const db = createTestDb();
     const longObservation = 'A'.repeat(150);
     db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('verbose-entity', 'note');
@@ -376,11 +393,10 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/trunctest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    // The snippet in the bullet should be exactly 100 chars (the first 100 'A's)
-    expect(additionalContext).toContain('• verbose-entity (note): ' + 'A'.repeat(100));
-    // The full 150-char string should NOT appear
-    expect(additionalContext).not.toContain('A'.repeat(150));
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toMatch(/[├└]─ 1 project memory/);
+    // Tree summary never embeds observation content — long or short.
+    expect(msg).not.toContain('A'.repeat(40));
   });
 
   it('Scenario: Proactive lesson warnings — lesson_learned entities shown with Prevention hint', () => {
@@ -403,13 +419,14 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/lessontest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).toContain('Known lessons');
-    expect(additionalContext).toContain('Always validate API responses before accessing properties');
-    expect(additionalContext).toContain('confidence: 1.5');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).toMatch(/└─ 1 active lesson/);
+    // Verbose lesson body must NOT leak into the summary
+    expect(msg).not.toContain('Always validate API responses');
+    expect(msg).not.toContain('confidence:');
   });
 
-  it('Scenario: Lesson warnings — no lessons -> no warning section appended', () => {
+  it('Scenario: Lesson warnings — no lessons -> no lesson branch appended', () => {
     const db = createScoringDb();
     db.prepare("INSERT INTO entities (name, type, confidence, status) VALUES (?, ?, ?, ?)")
       .run('normal-entity', 'component', 1.0, 'active');
@@ -418,7 +435,76 @@ describe('Feature: Session Start Hook', () => {
     db.close();
 
     const output = runHook({ cwd: '/tmp/nolessontest' });
-    const additionalContext = (output as { systemMessage: string }).systemMessage;
-    expect(additionalContext).not.toContain('Known lessons');
+    const msg = (output as { systemMessage: string }).systemMessage;
+    expect(msg).not.toContain('active lesson');
+  });
+
+  // ===========================================================================
+  // Test-only seams: marketplace-cache (no native module) + legacy SQLite (no
+  // exp/log functions). Both branches are reachable in production but neither
+  // fires on the developer machine where this suite runs, so each is gated by
+  // a `MEMESH_TEST_FORCE_*` env var that the hook reads before it would
+  // otherwise probe the runtime.
+  // ===========================================================================
+
+  describe('Scenario: Plugin-marketplace cache install (no better-sqlite3)', () => {
+    function runHookRaw(input: object, env: Record<string, string>): string {
+      const hookPath = path.resolve('scripts/hooks/session-start.js');
+      return execFileSync('node', [hookPath], {
+        input: JSON.stringify(input),
+        env: { ...process.env, MEMESH_DB_PATH: dbPath, ...env },
+        encoding: 'utf8',
+        timeout: 15000,
+      });
+    }
+
+    it('silently exits with empty stdout when MEMESH_TEST_FORCE_MISSING_NATIVE=1', () => {
+      // Pre-create a DB so the no-DB branch isn't what's being tested.
+      const db = createTestDb();
+      db.prepare('INSERT INTO entities (name, type) VALUES (?, ?)').run('cache-test', 'note');
+      db.close();
+
+      const stdout = runHookRaw(
+        { cwd: '/tmp/cache-test' },
+        { MEMESH_TEST_FORCE_MISSING_NATIVE: '1' },
+      );
+      // No JSON output — Claude Code MUST not see a malformed message that
+      // could disrupt the session. Trailing newline is acceptable.
+      expect(stdout.trim()).toBe('');
+    });
+  });
+
+  describe('Scenario: Legacy SQLite build (no exp/log functions)', () => {
+    it('falls back to linear/rational scoring SQL and still ranks entities', () => {
+      const db = createScoringDb();
+      // Insert 3 entities with distinct access_count + last_accessed_at so
+      // the legacy formula has signal to rank on.
+      db.prepare("INSERT INTO entities (name, type, access_count, last_accessed_at, confidence) VALUES (?, ?, ?, datetime('now'), ?)")
+        .run('hot', 'note', 50, 1.0);
+      db.prepare("INSERT INTO entities (name, type, access_count, last_accessed_at, confidence) VALUES (?, ?, ?, datetime('now', '-30 days'), ?)")
+        .run('warm', 'note', 10, 0.7);
+      db.prepare("INSERT INTO entities (name, type, access_count, last_accessed_at, confidence) VALUES (?, ?, ?, datetime('now', '-60 days'), ?)")
+        .run('cold', 'note', 1, 0.2);
+      for (let i = 1; i <= 3; i++) {
+        db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(i, `obs-${i}`);
+        db.prepare('INSERT INTO tags (entity_id, tag) VALUES (?, ?)').run(i, 'project:legacysql');
+      }
+      db.close();
+
+      const output = runHook(
+        { cwd: '/tmp/legacysql' },
+        { MEMESH_TEST_FORCE_LEGACY_SCORING_SQL: '1' },
+      );
+      const msg = (output as { systemMessage: string }).systemMessage;
+      // Tree summary still produced (legacy SQL works, just with different math)
+      expect(msg).toContain('◉ MeMesh memory loaded');
+      expect(msg).toMatch(/├─ 3 project memories/);
+
+      // Persisted entityNames preserve the ranking; "hot" should outrank "cold"
+      // under both math variants because every weighted factor agrees.
+      const session = readLatestSessionFile();
+      const names = session?.entityNames ?? [];
+      expect(names.indexOf('hot')).toBeLessThan(names.indexOf('cold'));
+    });
   });
 });


### PR DESCRIPTION
## Summary

Consolidates four parallel implementations that had silently drifted in memesh's filesystem and DB layer:

- **Path resolution** — `process.env.MEMESH_DB_PATH ?? path.join(os.homedir(), ...)` was inlined in 10+ core sites with subtly different fallbacks. Centralised into `src/core/paths.ts` (`homeDir`, `memeshDir`, `getDbPath`, `getMemeshDirFromDbPath`, `getProjectName`).
- **Hook DB migration chain** — `_shared.js openHookDb()` previously ran only the v2.11→v2.12 status migration; backfilled with the full 4-migration chain. Concurrent `ALTER TABLE` wrapped in `safeAlter()` so two hook processes racing on the same migration don't error out.
- **Session-start scoring** — used different math (linear cap + rational decay) and different weights than `core/scoring.ts` for the same factors. Rewritten to use SQLite's `log`/`exp` matching core exactly. New `SESSION_START_WEIGHT_RATIO` export is the single source of truth, with a test that fails if the SQL constants drift from it.
- **Schema duplication** — `SCHEMA_SQL` + `FTS_SQL` strings were duplicated byte-for-byte (per F5 boundary) with no drift guard. New `scripts/check-schema-drift.mjs` is wired into `npm run build`.

Also fixes a regression where an early-return in `session-summary.js` was skipping `runAutoUpdateAtStop()` (auto-update could miss pending updates at session end), a legacy-schema error in the lesson query that was being caught and discarded, and several bare-catch sites that were swallowing errors instead of surfacing them. One of those was masking an off-by-one in `resolvePluginRoot` (4.0.4–4.1.0) that prevented noise compression and LLM failure analysis from running on those versions.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `node scripts/check-schema-drift.mjs` — passes
- [x] `npx vitest run` — **920 / 920 passing** (added 2 coverage scenarios via `MEMESH_TEST_FORCE_*` env-var seams: marketplace-cache silent-skip + legacy-SQLite scoring fallback)
- [x] End-to-end smoke: `session-start.js` produces tree-format summary unchanged for end users (`◉ MeMesh memory loaded ├─ N project + M recent ...`).