### PR TITLE
fix(hooks): post-commit reads tool_response.stdout

### DIFF
--- a/scripts/hooks/post-commit.js
+++ b/scripts/hooks/post-commit.js
@@ -12,9 +12,27 @@ process.stdin.on('end', () => {
 
     // Only process Bash tool outputs
     if (data.tool_name !== 'Bash') return exit0();
-    const toolOutput = typeof data.tool_output === 'string'
-      ? data.tool_output
-      : JSON.stringify(data.tool_output || '');
+
+    // Claude Code's PostToolUse hook payload has had two field-name shapes:
+    // legacy `tool_output: <string>` and current
+    // `tool_response: { stdout, stderr, interrupted, isError }`. Prefer the
+    // current shape; fall back to legacy so unit-test fixtures (which use
+    // tool_output) keep working. This block existed only as the legacy
+    // branch — once Claude Code unified on tool_response the hook silently
+    // stopped seeing any output and never wrote commit entities again.
+    const tr = data.tool_response;
+    let toolOutput = '';
+    if (typeof tr === 'string') {
+      toolOutput = tr;
+    } else if (tr && typeof tr === 'object') {
+      const stdout = typeof tr.stdout === 'string' ? tr.stdout : '';
+      const stderr = typeof tr.stderr === 'string' ? tr.stderr : '';
+      toolOutput = stdout + (stderr ? '\n' + stderr : '');
+    } else if (typeof data.tool_output === 'string') {
+      toolOutput = data.tool_output;
+    } else if (data.tool_output != null) {
+      toolOutput = JSON.stringify(data.tool_output);
+    }
 
     // Detect git commit in output
     // Pattern: [branch hash] commit message

--- a/tests/hooks/post-commit.test.ts
+++ b/tests/hooks/post-commit.test.ts
@@ -202,4 +202,35 @@ describe('Feature: Post-Commit Hook', () => {
       timeout: 15000,
     });
   });
+
+  // Regression: Claude Code's PostToolUse hook payload uses
+  // `tool_response: { stdout, stderr, ... }` (current schema), not
+  // legacy `tool_output: <string>`. The hook silently stopped writing
+  // any commit entity once Claude Code unified on this shape, because
+  // the hook only consulted `tool_output`. This test pins the new
+  // shape so a future refactor can't regress it again.
+  it('Scenario: tool_response.stdout (current Claude Code schema) -> entity created', () => {
+    const input = {
+      tool_name: 'Bash',
+      cwd: '/tmp/myproject',
+      tool_input: { command: 'git commit -m "feat: tool_response shape"' },
+      tool_response: {
+        stdout: '[main c0ffee1] feat: tool_response shape\n 2 files changed, 8 insertions(+)',
+        stderr: '',
+        interrupted: false,
+        isError: false,
+      },
+    };
+
+    runHook(input);
+
+    const db = openDb();
+    const entity = db.prepare('SELECT * FROM entities WHERE name = ?').get('commit-c0ffee1');
+    expect(entity).toBeTruthy();
+    expect(entity.type).toBe('commit');
+    const obs = db.prepare('SELECT content FROM observations WHERE entity_id = ? ORDER BY id').all(entity.id);
+    const msgObs = obs.find((o: { content: string }) => o.content === 'feat: tool_response shape');
+    expect(msgObs).toBeTruthy();
+    db.close();
+  });
 });


### PR DESCRIPTION
## Summary

`scripts/hooks/post-commit.js` only read `data.tool_output` (the legacy field on the PostToolUse hook payload). Claude Code's PostToolUse payload now uses `tool_response: { stdout, stderr, interrupted, isError }`. With the hook reading only the legacy field, no `commit` entities were being written by the dogfooding workflow, so doctor's `hook-activity` check kept returning WARN even though hooks were correctly wired.

**Fix:** read `tool_response.stdout` first (concat with stderr if present), fall back to `tool_output` so existing test fixtures keep working without modification.

Added a regression test pinning the current shape (`tool_response.stdout`) so this stays covered.

## Test plan

- [x] `npx vitest run tests/hooks/post-commit.test.ts` — 10/10 passing (9 existing + 1 regression)
- [x] Local probe: hook fed `tool_response.stdout` writes a `commit` entity; legacy `tool_output` shape continues to work.