### PR TITLE
fix(hooks): session-summary default-allows when was_in_agentic_loop is absent

### DIFF
--- a/scripts/hooks/session-summary.js
+++ b/scripts/hooks/session-summary.js
@@ -170,7 +170,14 @@ process.stdin.on('end', async () => {
     const transcriptPath = inputData.transcript_path;
     const cwd = inputData.cwd || process.cwd();
     const stopReason = inputData.stop_reason || 'unknown';
-    const wasAgenticLoop = inputData.was_in_agentic_loop === true;
+    // Default-allow: when Claude Code's Stop payload omits
+    // `was_in_agentic_loop` (it has been silently absent in production
+    // for an unknown number of releases — symptom: zero session-insight
+    // entities written despite hooks otherwise wired correctly), fall
+    // back to "treat as agentic" so the toolCallCount<3 guard below is
+    // the real low-signal filter. Earlier this field was a hard gate
+    // (default-deny) and the hook silently never captured anything.
+    const wasAgenticLoop = inputData.was_in_agentic_loop !== false;
 
     // Guards: skip low-signal sessions
     if (stopReason === 'user_interrupt') return exit0();

--- a/tests/hooks/session-summary.test.ts
+++ b/tests/hooks/session-summary.test.ts
@@ -104,7 +104,7 @@ describe('Feature: Session Summary (Stop Hook)', () => {
     db.close();
   });
 
-  it('Scenario: Non-agentic session is skipped', () => {
+  it('Scenario: Non-agentic session is skipped (explicit was_in_agentic_loop: false)', () => {
     writeTranscript([
       { type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/tmp/proj/src/auth.ts' } },
     ]);
@@ -124,6 +124,34 @@ describe('Feature: Session Summary (Stop Hook)', () => {
       expect(count.c).toBe(0);
       db.close();
     }
+  });
+
+  // Regression: production Stop payloads were silently omitting
+  // `was_in_agentic_loop` for an unknown number of Claude Code releases,
+  // and the hook's default-deny gate (treat absent as false) caused zero
+  // session-insight entities to ever be written. Default-allow now: only
+  // an EXPLICIT `false` skips. This pins the new contract.
+  it('Scenario: Missing was_in_agentic_loop field still captures (default-allow)', () => {
+    writeTranscript([
+      { type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/tmp/proj/src/auth.ts' } },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'npm test' } },
+      { type: 'tool_use', tool_name: 'Read', tool_input: { file_path: '/tmp/proj/README.md' } },
+      { type: 'tool_result', content: 'pass' },
+    ]);
+
+    runHook({
+      session_id: 'test-sess-noflag',
+      transcript_path: transcriptPath,
+      cwd: '/tmp/myproject',
+      stop_reason: 'end_turn',
+      // no was_in_agentic_loop — simulates current Claude Code Stop payload
+    });
+
+    expect(fs.existsSync(dbPath)).toBe(true);
+    const db = openDb();
+    const insights = db.prepare("SELECT COUNT(*) as c FROM entities WHERE type = 'session-insight'").get() as any;
+    expect(insights.c).toBeGreaterThan(0);
+    db.close();
   });
 
   it('Scenario: User interrupt is skipped', () => {


### PR DESCRIPTION
## Summary

`scripts/hooks/session-summary.js` checked `inputData.was_in_agentic_loop === true` as a hard gate (default-deny). Claude Code's Stop hook payload no longer always carries that field, and an absent field meant the hook returned early without ever writing a \`session-insight\` entity. Doctor's \`hook-activity\` check could surface this as a persistent WARN.

**Fix:** default-allow. Only an explicit \`was_in_agentic_loop: false\` skips. The \`toolCallCount < 3\` filter remains as the real low-signal guard.

Same root-cause shape as #37 (post-commit reading \`tool_output\` after the payload schema unified on \`tool_response\`). Added a regression test pinning the absent-field path.

## Test plan

- [x] \`npx vitest run tests/hooks/session-summary.test.ts\` — 9/9 passing (8 existing + 1 regression)
- [x] Local probe: feeding a Stop payload without \`was_in_agentic_loop\` writes 3 session-insight entities (files / fixes / summary).