### PR TITLE
feat(v4.3.0): KG connectivity + roadmap PM filter + PM analytics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.2.0",
+  "version": "4.3.0",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.3.0] — 2026-05-11
+
+KG connectivity + dashboard PM filter release. Reduces entity orphan rate from 89.2% → 11.7% on a real-world knowledge base using two new non-LLM heuristics; adds milestone signal filtering to the Roadmap view; and introduces PM-framed analytics. +26 tests (984 → 1010 passing).
+
+### Added
+- **KG backfill Rule 3 — session co-occurrence** (`src/core/kg-backfill.ts`) — high-signal orphan entities sharing a `session:*` tag get a `co-created` relation. Gate: `signal_score ≥ 0.6` (reads entity `metadata`). Eligible types: lesson_learned, decision, architecture, feature, bug_fix, pattern, etc. Exposed via `memesh kg backfill-relations --session-cooccurrence`.
+- **KG backfill Rule 4 — name-token similarity** (`src/core/kg-backfill.ts`) — orphans whose tokenized names share ≥ 3 content tokens OR Jaccard similarity ≥ 0.50 get a `shares-name-tokens` relation. `tokenizeName()` and `jaccardSimilarity()` exported as pure functions. Stopword list extended with generic qualifiers, process/lifecycle terms, and month abbreviations to prevent cartesian explosion (same class of problem as the "completed" tag bug in Rule 1). Exposed via `memesh kg backfill-relations --name-tokens [--min-jaccard N]`.
+- **`memesh kg backfill-relations --all-rules`** — convenience flag enabling Rules 1–4 in a single pass.
+- **PM Analytics endpoint** (`GET /v1/analytics/pm?window=N`) — pure-SQL aggregation: decision velocity (decisions/week, releases/month), staleness (stale plans ≥30d, open decisions ≥14d), connectedness (orphan rate, total relations, active entities). Zero LLM dependency.
+- **Dashboard PM Analytics panel** (`dashboard/src/components/PmAnalyticsPanel.tsx`) — 4-stat grid surfacing the PM metrics in the Analytics tab. Color-coded orphan rate (green/amber/red). Fails silently if the endpoint is unavailable.
+- **Dashboard milestone signal filter** (`dashboard/src/components/ProjectRoadmap.tsx`) — Roadmap milestone rail now filters out `feature`-type milestones with `signal_score < 0.65`, reducing noise from low-confidence auto-captured entries. Releases are always shown regardless of score. A "(N low-signal hidden)" badge appears when entries are filtered.
+- **Integration test** (`tests/core/kg-backfill-integration.test.ts`) — seeds 46 entities across sessions, name-token clusters, and noise types; verifies orphan rate < 50% after all-rules backfill.
+
+### Fixed
+- **`doctor.test.ts` non-hermetic** — "reports PASS_WITH_CONCERNS" test was reading the real `~/.memesh/install-hooks.json`, which could have a stale `plugin_root` → `hook-wiring` returned `fail`. Test now sets `MEMESH_DIR` to an isolated temp dir like the other hermetic doctor tests.
+
 ## [4.2.0] — 2026-05-10
 
 A combined release covering recall-path simplification, cross-provider LLM failover, end-to-end LLM telemetry, the new Insights / Analytics dashboard surfaces, KG-connectivity work, and a clean-slate quality bar (0 lint warnings, 0 executable `any` in src/). +6k LOC, +46 tests (938 → 984 passing). Highlights below grouped per Keep-a-Changelog convention.

--- a/dashboard/src/components/AnalyticsTab.tsx
+++ b/dashboard/src/components/AnalyticsTab.tsx
@@ -7,6 +7,7 @@ import { MemoryAgeMatrix } from './MemoryAgeMatrix';
 import { KnowledgeRadar } from './KnowledgeRadar';
 import { UserPatterns } from './UserPatterns';
 import { LlmTelemetryPanel } from './LlmTelemetryPanel';
+import { PmAnalyticsPanel } from './PmAnalyticsPanel';
 import { t } from '../lib/i18n';
 
 export function AnalyticsTab() {
@@ -94,6 +95,9 @@ export function AnalyticsTab() {
       <div style={{ marginTop: 8 }}>
         <LlmTelemetryPanel />
       </div>
+
+      {/* Row 5c: PM metrics — velocity, open decisions, KG orphan rate. */}
+      <PmAnalyticsPanel />
 
       {/* Row 6: Topics cloud */}
       {stats && (() => {

--- a/dashboard/src/components/PmAnalyticsPanel.tsx
+++ b/dashboard/src/components/PmAnalyticsPanel.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'preact/hooks';
+import { api } from '../lib/api';
+
+interface PmAnalytics {
+  velocity: { decisionsPerWeek: number; releasesPerMonth: number; windowDays: number };
+  staleness: { stalePlanCount: number; openDecisionCount: number };
+  connectedness: { orphanRate: number; totalRelations: number; activeEntities: number };
+}
+
+export function PmAnalyticsPanel() {
+  const [data, setData] = useState<PmAnalytics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api<{ data: PmAnalytics }>('GET', '/v1/analytics/pm')
+      .then((r) => setData(r.data))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) return null; // fail silently — panel is supplementary
+  if (!data) return null;
+
+  const orphanPct = (data.connectedness.orphanRate * 100).toFixed(1);
+  const orphanColor =
+    data.connectedness.orphanRate > 0.7 ? '#ef4444'
+    : data.connectedness.orphanRate > 0.4 ? '#f59e0b'
+    : '#22c55e';
+
+  return (
+    <div class="card" style={{ marginTop: 8, padding: 16 }}>
+      <div class="card-title" style={{ marginBottom: 12 }}>PM Metrics</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 22, fontWeight: 700, fontFamily: 'var(--font-mono)' }}>
+            {data.velocity.decisionsPerWeek.toFixed(1)}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 2 }}>decisions/week</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 22, fontWeight: 700, fontFamily: 'var(--font-mono)' }}>
+            {data.staleness.openDecisionCount}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 2 }}>open decisions (&gt;14d)</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 22, fontWeight: 700, fontFamily: 'var(--font-mono)', color: orphanColor }}>
+            {orphanPct}%
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 2 }}>KG orphan rate</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 22, fontWeight: 700, fontFamily: 'var(--font-mono)' }}>
+            {data.connectedness.totalRelations}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 2 }}>relations total</div>
+        </div>
+      </div>
+      {data.staleness.stalePlanCount > 0 && (
+        <div style={{ marginTop: 10, fontSize: 12, color: '#f59e0b' }}>
+          {data.staleness.stalePlanCount} plan{data.staleness.stalePlanCount > 1 ? 's' : ''} not reviewed in 30+ days
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/ProjectRoadmap.tsx
+++ b/dashboard/src/components/ProjectRoadmap.tsx
@@ -10,6 +10,13 @@ import { EntityIcon } from './icons/EntityIcon';
  *  secondary signals only when explicitly tagged. */
 const MILESTONE_TYPES = new Set(['release', 'feature']);
 
+/** Milestone signal gate: feature/plan/decision entries below this are
+ *  filtered from the milestone rail. 'release' type is always exempt —
+ *  a shipped release is always PM-meaningful regardless of score. Entities
+ *  without signal_score (created before the scorer) pass through unfiltered. */
+const MILESTONE_SIGNAL_THRESHOLD = 0.65;
+const MILESTONE_ALWAYS_INCLUDE_TYPES = new Set(['release']);
+
 /** Type set that qualifies as a "key lesson" — drives the right rail. */
 const LESSON_TYPES = new Set([
   'lesson_learned', 'lesson', 'mistake', 'bug_fix',
@@ -258,14 +265,25 @@ export function ProjectRoadmap({ projectName, entities, onSwitchToList }: Props)
 
   const groups = useMemo(() => groupByDate(entities), [entities]);
 
-  // Milestones: release/feature entities, newest first, capped at 6
-  const milestones = useMemo(
-    () => entities
-      .filter((e) => MILESTONE_TYPES.has(e.type))
+  // Milestones: release/feature entities, signal-gated, newest first, capped at 6.
+  // 'release' type is always included; legacy entities (no signal_score) pass through.
+  const milestones = useMemo(() => {
+    return entities
+      .filter((e) => {
+        if (!MILESTONE_TYPES.has(e.type)) return false;
+        if (MILESTONE_ALWAYS_INCLUDE_TYPES.has(e.type)) return true;
+        const score = (e.metadata as Record<string, unknown> | undefined)?.signal_score;
+        if (typeof score !== 'number') return true; // legacy: pass through
+        return score >= MILESTONE_SIGNAL_THRESHOLD;
+      })
       .sort((a, b) => b.created_at.localeCompare(a.created_at))
-      .slice(0, 6),
-    [entities],
-  );
+      .slice(0, 6);
+  }, [entities]);
+
+  const filteredMilestoneCount = useMemo(() => {
+    const eligible = entities.filter((e) => MILESTONE_TYPES.has(e.type));
+    return eligible.length - milestones.length;
+  }, [entities, milestones]);
 
   // Key lessons: top 5 lesson types by access_count desc
   const keyLessons = useMemo(
@@ -787,8 +805,13 @@ export function ProjectRoadmap({ projectName, entities, onSwitchToList }: Props)
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14, position: 'sticky', top: 16 }}>
           {milestones.length > 0 && (
             <div class="card" style={{ padding: 14 }}>
-              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, color: 'var(--text-2)', marginBottom: 10 }}>
+              <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, color: 'var(--text-2)', marginBottom: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
                 {t('roadmap.milestones')}
+                {filteredMilestoneCount > 0 && (
+                  <span style={{ fontSize: '0.7rem', fontWeight: 400, opacity: 0.55, textTransform: 'none', letterSpacing: 0 }}>
+                    ({filteredMilestoneCount} low-signal hidden)
+                  </span>
+                )}
               </div>
               {milestones.map((m) => (
                 <button

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -1,0 +1,76 @@
+{
+  "schema": "memesh.skills-manifest/v1",
+  "generated_at": "2026-05-11T06:30:37.315Z",
+  "entries": [
+    {
+      "path": ".claude-plugin/plugin.json",
+      "sha256": "d3009a03016f1a724f7cbc7bd1083df017cf7e3e42a268a38093d26dd777b5ab",
+      "bytes": 441
+    },
+    {
+      "path": ".mcp.json",
+      "sha256": "51a8f054a6388ae093597ffde4d09acb4693de5f026fc1156a49647dca60d12f",
+      "bytes": 132
+    },
+    {
+      "path": "hooks/hooks.json",
+      "sha256": "ea54bdce8d52e14acdc3e5ddf3c7f241e6cfb45952ca720bbd4618d5bf94a241",
+      "bytes": 1767
+    },
+    {
+      "path": "scripts/hooks/_shared.js",
+      "sha256": "ee0e190f0c3a5b835a444c35f42f4cdd1d2217a6ebba2303d50212b2077a5287",
+      "bytes": 26463
+    },
+    {
+      "path": "scripts/hooks/post-commit.js",
+      "sha256": "0739155a05e54c4fd6056a4fff4a95878e1be631382f517c325e7f66990e7ef3",
+      "bytes": 6590
+    },
+    {
+      "path": "scripts/hooks/pre-bash-orchestration-nudge.js",
+      "sha256": "d8dac333d31634b91109ee12a5ff00ea14fb1c7fd12609cdab5b5d244cb6d40a",
+      "bytes": 6458
+    },
+    {
+      "path": "scripts/hooks/pre-compact.js",
+      "sha256": "31609cb91443e69da2509a38a62ea8597ce16a15ca19bc40b0de0c5b9e1d4bf1",
+      "bytes": 5469
+    },
+    {
+      "path": "scripts/hooks/pre-edit-recall.js",
+      "sha256": "b101eef853c3ed6deab317ed0b4f6cd81c024e6b54d60fda82a6c6468c166b0b",
+      "bytes": 6718
+    },
+    {
+      "path": "scripts/hooks/session-start.js",
+      "sha256": "2e6114f0260d494408f5332500536f2f08b9c12012b241e468aa0bba149b8f96",
+      "bytes": 31390
+    },
+    {
+      "path": "scripts/hooks/session-summary.js",
+      "sha256": "013f2aaefc323c100ab325407842a70d12fb4a5eef885c7d8e2eb4d33dd175ad",
+      "bytes": 32954
+    },
+    {
+      "path": "scripts/hooks/user-prompt-intent.js",
+      "sha256": "75143339c275ca3ec034d04454bd1e02281dcb892f4cb1515508a912466d699b",
+      "bytes": 7457
+    },
+    {
+      "path": "skills/agentic-orchestration/SKILL.md",
+      "sha256": "d06d0c3e1fb03cee675aff26b4b26f24111b9e9f6be9ccd4e1945ef454314f1c",
+      "bytes": 18202
+    },
+    {
+      "path": "skills/memesh-review/SKILL.md",
+      "sha256": "ed58c6dc0131ab332ac3c5bb7963476f169d723eee2587621328415402a36f01",
+      "bytes": 3588
+    },
+    {
+      "path": "skills/memesh/SKILL.md",
+      "sha256": "3e594f4db08ad51e8ff74426ce909ab9eda6fa13ee1a2b21ec3c7f29b7dd1a07",
+      "bytes": 6546
+    }
+  ]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.2.0
+**Version**: 4.3.0
 
 ---
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.2.0
+**Version**: 4.3.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---
@@ -658,6 +658,44 @@ Returns computed analytics insights for the memory database.
 - Quality (30%): percentage of active entities with confidence > 0.7
 - Freshness (20%): new entities this week relative to 5% of total (capped at 100%)
 - Lessons (20%): lesson_learned entity count, 5+ gives full score
+
+### GET /v1/analytics/pm
+
+Returns PM-framed metrics: decision velocity, knowledge-graph connectedness, and staleness indicators. Designed for the dashboard PM Analytics panel.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `window` | number | 30 | Lookback window in days for velocity calculations |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "velocity": {
+      "decisionsPerWeek": 2.1,
+      "releasesPerMonth": 0.5,
+      "windowDays": 30
+    },
+    "staleness": {
+      "stalePlanCount": 1,
+      "openDecisionCount": 3
+    },
+    "connectedness": {
+      "orphanRate": 0.117,
+      "totalRelations": 2970,
+      "activeEntities": 1326
+    }
+  }
+}
+```
+
+- `stalePlanCount`: active `plan` entities not accessed in 30+ days
+- `openDecisionCount`: active `decision` entities not accessed in 14+ days
+- `orphanRate`: fraction of active entities with zero relations (lower = better connected KG)
 
 ### POST /v1/config/test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/core/analytics.ts
+++ b/src/core/analytics.ts
@@ -395,22 +395,21 @@ export function computePmAnalytics(
   db: Database.Database,
   windowDays = 30,
 ): PmAnalyticsResult {
-  const since = new Date(Date.now() - windowDays * 86400 * 1000).toISOString();
-  const staleThreshold = new Date(Date.now() - 30 * 86400 * 1000).toISOString();
-
   const decisionsInWindow = (db.prepare(
-    `SELECT COUNT(*) AS n FROM entities WHERE type='decision' AND status='active' AND created_at >= ?`,
-  ).get(since) as { n: number }).n;
+    `SELECT COUNT(*) AS n FROM entities WHERE type='decision' AND status='active'
+     AND created_at >= datetime('now', '-' || ? || ' days')`,
+  ).get(windowDays) as { n: number }).n;
 
   const releasesInWindow = (db.prepare(
-    `SELECT COUNT(*) AS n FROM entities WHERE type='release' AND status='active' AND created_at >= ?`,
-  ).get(since) as { n: number }).n;
+    `SELECT COUNT(*) AS n FROM entities WHERE type='release' AND status='active'
+     AND created_at >= datetime('now', '-' || ? || ' days')`,
+  ).get(windowDays) as { n: number }).n;
 
   const stalePlans = (db.prepare(
     `SELECT COUNT(*) AS n FROM entities
      WHERE type='plan' AND status='active'
-       AND (last_accessed_at IS NULL OR last_accessed_at < ?)`,
-  ).get(staleThreshold) as { n: number }).n;
+       AND (last_accessed_at IS NULL OR last_accessed_at < datetime('now', '-30 days'))`,
+  ).get() as { n: number }).n;
 
   // Open decisions: created > 14 days ago and not yet superseded by another entity.
   const openDecisions = (db.prepare(

--- a/src/core/analytics.ts
+++ b/src/core/analytics.ts
@@ -369,3 +369,92 @@ export function computeAnalytics(db: Database.Database): AnalyticsResult {
     knowledgeRadar,
   };
 }
+
+export interface PmAnalyticsResult {
+  velocity: {
+    decisionsPerWeek: number;
+    releasesPerMonth: number;
+    windowDays: number;
+  };
+  staleness: {
+    stalePlanCount: number;
+    openDecisionCount: number;
+  };
+  connectedness: {
+    orphanRate: number;
+    totalRelations: number;
+    activeEntities: number;
+  };
+}
+
+/**
+ * PM-framed analytics: velocity, staleness, KG connectedness.
+ * All reads; no LLM. windowDays controls the velocity lookback (default 30).
+ */
+export function computePmAnalytics(
+  db: Database.Database,
+  windowDays = 30,
+): PmAnalyticsResult {
+  const since = new Date(Date.now() - windowDays * 86400 * 1000).toISOString();
+  const staleThreshold = new Date(Date.now() - 30 * 86400 * 1000).toISOString();
+
+  const decisionsInWindow = (db.prepare(
+    `SELECT COUNT(*) AS n FROM entities WHERE type='decision' AND status='active' AND created_at >= ?`,
+  ).get(since) as { n: number }).n;
+
+  const releasesInWindow = (db.prepare(
+    `SELECT COUNT(*) AS n FROM entities WHERE type='release' AND status='active' AND created_at >= ?`,
+  ).get(since) as { n: number }).n;
+
+  const stalePlans = (db.prepare(
+    `SELECT COUNT(*) AS n FROM entities
+     WHERE type='plan' AND status='active'
+       AND (last_accessed_at IS NULL OR last_accessed_at < ?)`,
+  ).get(staleThreshold) as { n: number }).n;
+
+  // Open decisions: created > 14 days ago and not yet superseded by another entity.
+  const openDecisions = (db.prepare(
+    `SELECT COUNT(*) AS n FROM entities e
+     WHERE e.type='decision' AND e.status='active'
+       AND e.created_at < datetime('now', '-14 days')
+       AND NOT EXISTS (
+         SELECT 1 FROM relations r
+         WHERE r.from_entity_id=e.id AND r.relation_type='supersedes'
+       )`,
+  ).get() as { n: number }).n;
+
+  const totalActive = (db.prepare(
+    `SELECT COUNT(*) AS n FROM entities WHERE status='active'`,
+  ).get() as { n: number }).n;
+
+  const withRelations = (db.prepare(
+    `SELECT COUNT(DISTINCT e.id) AS n
+     FROM entities e
+     JOIN relations r ON r.from_entity_id=e.id OR r.to_entity_id=e.id
+     WHERE e.status='active'`,
+  ).get() as { n: number }).n;
+
+  const totalRelations = (db.prepare(
+    `SELECT COUNT(*) AS n FROM relations`,
+  ).get() as { n: number }).n;
+
+  const weeks = windowDays / 7;
+  const months = windowDays / 30;
+
+  return {
+    velocity: {
+      decisionsPerWeek: weeks > 0 ? decisionsInWindow / weeks : 0,
+      releasesPerMonth: months > 0 ? releasesInWindow / months : 0,
+      windowDays,
+    },
+    staleness: {
+      stalePlanCount: stalePlans,
+      openDecisionCount: openDecisions,
+    },
+    connectedness: {
+      orphanRate: totalActive > 0 ? (totalActive - withRelations) / totalActive : 0,
+      totalRelations,
+      activeEntities: totalActive,
+    },
+  };
+}

--- a/src/core/kg-backfill.ts
+++ b/src/core/kg-backfill.ts
@@ -56,13 +56,27 @@ const NAME_STOPWORDS = new Set([
   'the','and','for','with','from','this','that','are','was','has',
   'fix','add','get','set','use','via','not','new','old','update',
   'into','onto','when','then','also','both','each','more','about',
+  // Generic qualifier words that appear across many entity names without
+  // carrying topical signal (e.g. "X Best Practices", "Y Pattern Applied").
+  // Without this, any two "Best Practices" entities match on "best"+"practices"
+  // — same cartesian-explosion class as the "completed" tag bug.
+  'best','practices','pattern','applied','standards','professional',
+  'using','based','related','general','common','basic','simple',
+  // Process / lifecycle words — describe HOW, not WHAT.
+  'verification','cleanup','refactoring','implementation','migration',
+  'summary','overview','analysis','review','report','notes',
+  // Month abbreviations — dates in entity names cause cartesian pairing.
+  'jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec',
 ]);
+
+const NUMERIC_RE = /^\d+$/;
 
 export function tokenizeName(name: string): Set<string> {
   return new Set(
     name.toLowerCase()
         .split(/[\W_]+/)
-        .filter((t) => t.length >= 3 && !NAME_STOPWORDS.has(t))
+        // Filter: minimum length, not a stopword, not a bare number (year, count, etc.)
+        .filter((t) => t.length >= 3 && !NAME_STOPWORDS.has(t) && !NUMERIC_RE.test(t))
   );
 }
 
@@ -125,9 +139,10 @@ export interface BackfillOptions {
   minSessionSignalScore?: number;
   /** Rule 4: link orphans sharing ≥N name content tokens. Default false. */
   includeNameTokenSimilarity?: boolean;
-  /** Min Jaccard for Rule 4. Default 0.25. */
+  /** Min Jaccard for Rule 4. Default 0.50 (share ≥ half the tokens). Lower values
+   *  produce more edges but risk quality degradation on large KBs. */
   minNameJaccard?: number;
-  /** Alt gate for Rule 4: ≥N shared tokens also qualifies. Default 2. */
+  /** Alt gate for Rule 4: ≥N shared tokens also qualifies. Default 3. */
   minSharedNameTokens?: number;
 }
 
@@ -440,8 +455,8 @@ export function proposeBackfillCandidates(opts: BackfillOptions = {}, db?: Datab
   // Orphans whose names share ≥ minSharedNameTokens content tokens
   // (or Jaccard ≥ minNameJaccard) are related in subject matter.
   if (opts.includeNameTokenSimilarity) {
-    const minJaccard = opts.minNameJaccard ?? 0.25;
-    const minSharedTokens = opts.minSharedNameTokens ?? 2;
+    const minJaccard = opts.minNameJaccard ?? 0.50;
+    const minSharedTokens = opts.minSharedNameTokens ?? 3;
 
     // Pre-compute token sets for all active entities.
     const tokensByEntity = new Map<number, Set<string>>();

--- a/src/core/kg-backfill.ts
+++ b/src/core/kg-backfill.ts
@@ -428,11 +428,15 @@ export function proposeBackfillCandidates(opts: BackfillOptions = {}, db?: Datab
 
       const sessionTags = sessionTagsByOrphan.get(orphan.id) ?? [];
       let added = 0;
+      // Track already-proposed peers so an orphan sharing multiple
+      // session tags with the same peer doesn't produce duplicate edges.
+      const proposedPeers = new Set<number>();
 
       for (const stag of sessionTags) {
         const peers = (entitiesBySession.get(stag) ?? []).filter((id) => id !== orphan.id);
         for (const peerId of peers) {
           if (added >= maxPerSource) break;
+          if (proposedPeers.has(peerId)) continue;
           const peer = entityById.get(peerId);
           if (!peer) continue;
           candidates.push({
@@ -444,6 +448,7 @@ export function proposeBackfillCandidates(opts: BackfillOptions = {}, db?: Datab
             reason: `co-created in same session (${stag})`,
             strength: 2,
           });
+          proposedPeers.add(peerId);
           added++;
         }
         if (added >= maxPerSource) break;

--- a/src/core/kg-backfill.ts
+++ b/src/core/kg-backfill.ts
@@ -52,6 +52,27 @@ const SYSTEM_TAG_LITERALS = new Set([
 // YYYY-MM-DD pattern (date stamps that snuck through some tag pipelines)
 const DATE_TAG_RE = /^\d{4}-\d{2}-\d{2}/;
 
+const NAME_STOPWORDS = new Set([
+  'the','and','for','with','from','this','that','are','was','has',
+  'fix','add','get','set','use','via','not','new','old','update',
+  'into','onto','when','then','also','both','each','more','about',
+]);
+
+export function tokenizeName(name: string): Set<string> {
+  return new Set(
+    name.toLowerCase()
+        .split(/[\W_]+/)
+        .filter((t) => t.length >= 3 && !NAME_STOPWORDS.has(t))
+  );
+}
+
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const t of a) { if (b.has(t)) intersection++; }
+  return intersection / (a.size + b.size - intersection);
+}
+
 /**
  * Whether a tag carries enough topical signal to gate co-occurrence.
  * Conservative on purpose — false positives become bogus edges that
@@ -80,7 +101,7 @@ export interface RelationCandidate {
   fromName: string;
   toEntityId: number;
   toName: string;
-  relationType: 'related-to' | 'belongs-to-project';
+  relationType: 'related-to' | 'belongs-to-project' | 'co-created' | 'shares-name-tokens';
   /** Why we proposed this edge — for the CLI dry-run preview. */
   reason: string;
   /** Strength signal — number of shared topical tags or recency in days. */
@@ -98,13 +119,28 @@ export interface BackfillOptions {
   includeArchived?: boolean;
   /** When true, only propose; never write. Same shape used by both modes. */
   dryRun?: boolean;
+  /** Rule 3: link high-signal orphans co-created in the same session. Default false. */
+  includeSessionCooccurrence?: boolean;
+  /** Min signal_score for Rule 3 participants. Default 0.6. */
+  minSessionSignalScore?: number;
+  /** Rule 4: link orphans sharing ≥N name content tokens. Default false. */
+  includeNameTokenSimilarity?: boolean;
+  /** Min Jaccard for Rule 4. Default 0.25. */
+  minNameJaccard?: number;
+  /** Alt gate for Rule 4: ≥N shared tokens also qualifies. Default 2. */
+  minSharedNameTokens?: number;
 }
 
 export interface BackfillResult {
   candidatesProposed: number;
   edgesWritten: number;
   dryRun: boolean;
-  byRule: { tagCooccurrence: number; projectClustering: number };
+  byRule: {
+    tagCooccurrence: number;
+    projectClustering: number;
+    sessionCooccurrence: number;
+    nameTokenSimilarity: number;
+  };
 }
 
 interface OrphanRow {
@@ -133,7 +169,7 @@ export function backfillRelations(opts: BackfillOptions = {}, db?: Database.Data
     candidatesProposed: candidates.length,
     edgesWritten: 0,
     dryRun: !!opts.dryRun,
-    byRule: { tagCooccurrence: 0, projectClustering: 0 },
+    byRule: { tagCooccurrence: 0, projectClustering: 0, sessionCooccurrence: 0, nameTokenSimilarity: 0 },
   };
 
   if (opts.dryRun) return result;
@@ -151,6 +187,8 @@ export function backfillRelations(opts: BackfillOptions = {}, db?: Database.Data
         result.edgesWritten++;
         if (c.relationType === 'related-to') result.byRule.tagCooccurrence++;
         else if (c.relationType === 'belongs-to-project') result.byRule.projectClustering++;
+        else if (c.relationType === 'co-created') result.byRule.sessionCooccurrence++;
+        else if (c.relationType === 'shares-name-tokens') result.byRule.nameTokenSimilarity++;
       }
     }
   });
@@ -211,12 +249,13 @@ export function proposeBackfillCandidates(opts: BackfillOptions = {}, db?: Datab
   for (const o of orphans) orphanById.set(o.id, o);
 
   // Build a lookup of all entity name+type for the from/to fields.
-  // Use the alias `e` consistently so `${statusFilter}` (which is
-  // `AND e.status = 'active'`) resolves correctly.
+  // Include metadata so Rules 3+4 can read signal_score without a
+  // second query. Use the alias `e` consistently so `${statusFilter}`
+  // (`AND e.status = 'active'`) resolves correctly.
   const allEntities = conn.prepare(
-    `SELECT e.id, e.name, e.type FROM entities e WHERE 1=1 ${statusFilter}`
-  ).all() as Array<{ id: number; name: string; type: string }>;
-  const entityById = new Map<number, { id: number; name: string; type: string }>();
+    `SELECT e.id, e.name, e.type, e.metadata FROM entities e WHERE 1=1 ${statusFilter}`
+  ).all() as Array<{ id: number; name: string; type: string; metadata: string | null }>;
+  const entityById = new Map<number, { id: number; name: string; type: string; metadata: string | null }>();
   for (const e of allEntities) entityById.set(e.id, e);
 
   // ---- Rule 1: Tag co-occurrence ----
@@ -318,6 +357,130 @@ export function proposeBackfillCandidates(opts: BackfillOptions = {}, db?: Datab
       reason: `same-project anchor (${anchor.type})`,
       strength: 1,
     });
+  }
+
+  // ---- Rule 3: Session co-occurrence ----
+  // High-signal orphans that share a session: tag are co-created —
+  // they emerged from the same conversation and likely share context.
+  if (opts.includeSessionCooccurrence) {
+    const minScore = opts.minSessionSignalScore ?? 0.6;
+    const sessionEligibleTypes = new Set([
+      'lesson_learned', 'lesson', 'decision', 'architecture', 'architecture_decision',
+      'plan', 'feature', 'bug_fix', 'pattern', 'best_practice', 'release',
+    ]);
+
+    // Parse signal_score helper — missing score defaults to include (1.0).
+    const getSignalScore = (meta: string | null): number => {
+      try {
+        const parsed = JSON.parse(meta ?? '{}');
+        const s = parsed?.signal_score;
+        return typeof s === 'number' ? s : 1.0;
+      } catch { return 1.0; }
+    };
+
+    // Load session: tags for all entities (not just orphans — peers may have relations).
+    const sessionTagRows = conn.prepare(`
+      SELECT t.entity_id, t.tag
+      FROM tags t
+      JOIN entities e ON e.id = t.entity_id
+      WHERE 1=1 ${statusFilter}
+        AND t.tag LIKE 'session:%'
+    `).all() as TagRow[];
+
+    // Group eligible entity ids by session: tag.
+    const entitiesBySession = new Map<string, number[]>();
+    for (const row of sessionTagRows) {
+      const ent = entityById.get(row.entity_id);
+      if (!ent || !sessionEligibleTypes.has(ent.type)) continue;
+      if (getSignalScore(ent.metadata) < minScore) continue;
+      let list = entitiesBySession.get(row.tag);
+      if (!list) { list = []; entitiesBySession.set(row.tag, list); }
+      list.push(row.entity_id);
+    }
+
+    // Build session: tag list per orphan for fast lookup.
+    const sessionTagsByOrphan = new Map<number, string[]>();
+    for (const row of sessionTagRows) {
+      if (!orphanById.has(row.entity_id)) continue;
+      let list = sessionTagsByOrphan.get(row.entity_id);
+      if (!list) { list = []; sessionTagsByOrphan.set(row.entity_id, list); }
+      list.push(row.tag);
+    }
+
+    for (const orphan of orphans) {
+      if (!sessionEligibleTypes.has(orphan.type)) continue;
+      if (getSignalScore(orphan.metadata) < minScore) continue;
+
+      const sessionTags = sessionTagsByOrphan.get(orphan.id) ?? [];
+      let added = 0;
+
+      for (const stag of sessionTags) {
+        const peers = (entitiesBySession.get(stag) ?? []).filter((id) => id !== orphan.id);
+        for (const peerId of peers) {
+          if (added >= maxPerSource) break;
+          const peer = entityById.get(peerId);
+          if (!peer) continue;
+          candidates.push({
+            fromEntityId: orphan.id,
+            fromName: orphan.name,
+            toEntityId: peer.id,
+            toName: peer.name,
+            relationType: 'co-created',
+            reason: `co-created in same session (${stag})`,
+            strength: 2,
+          });
+          added++;
+        }
+        if (added >= maxPerSource) break;
+      }
+    }
+  }
+
+  // ---- Rule 4: Name token similarity ----
+  // Orphans whose names share ≥ minSharedNameTokens content tokens
+  // (or Jaccard ≥ minNameJaccard) are related in subject matter.
+  if (opts.includeNameTokenSimilarity) {
+    const minJaccard = opts.minNameJaccard ?? 0.25;
+    const minSharedTokens = opts.minSharedNameTokens ?? 2;
+
+    // Pre-compute token sets for all active entities.
+    const tokensByEntity = new Map<number, Set<string>>();
+    for (const e of allEntities) {
+      const tokens = tokenizeName(e.name);
+      if (tokens.size >= 2) tokensByEntity.set(e.id, tokens);
+    }
+
+    for (const orphan of orphans) {
+      const orphanTokens = tokensByEntity.get(orphan.id);
+      if (!orphanTokens) continue;
+
+      const scored: Array<{ id: number; shared: number; jaccard: number }> = [];
+      for (const [candidateId, candidateTokens] of tokensByEntity) {
+        if (candidateId === orphan.id) continue;
+        let shared = 0;
+        for (const t of orphanTokens) { if (candidateTokens.has(t)) shared++; }
+        if (shared === 0) continue;
+        const jaccard = jaccardSimilarity(orphanTokens, candidateTokens);
+        if (shared >= minSharedTokens || jaccard >= minJaccard) {
+          scored.push({ id: candidateId, shared, jaccard });
+        }
+      }
+
+      scored.sort((a, b) => b.shared - a.shared || b.jaccard - a.jaccard);
+      for (const { id: peerId, shared, jaccard } of scored.slice(0, maxPerSource)) {
+        const peer = entityById.get(peerId);
+        if (!peer) continue;
+        candidates.push({
+          fromEntityId: orphan.id,
+          fromName: orphan.name,
+          toEntityId: peer.id,
+          toName: peer.name,
+          relationType: 'shares-name-tokens',
+          reason: `${shared} shared name token(s), Jaccard=${jaccard.toFixed(2)}`,
+          strength: shared,
+        });
+      }
+    }
   }
 
   return candidates;

--- a/src/transports/cli/cli.ts
+++ b/src/transports/cli/cli.ts
@@ -691,16 +691,24 @@ kgCmd
   .option('--max-per-source <n>', 'Max edges per orphan (default 3)', (v) => parseInt(v, 10), 3)
   .option('--min-shared-tags <n>', 'Min shared topical tags to gate co-occurrence rule (default 2)', (v) => parseInt(v, 10), 2)
   .option('--include-archived', 'Also process archived entities')
+  .option('--session-cooccurrence', 'Rule 3: link high-signal orphans co-created in the same session')
+  .option('--name-tokens', 'Rule 4: link orphans sharing ≥2 name content tokens')
+  .option('--min-jaccard <n>', 'Jaccard threshold for name similarity (default 0.25)', parseFloat)
+  .option('--all-rules', 'Enable all heuristic rules (Rules 1–4)')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
     await withDatabase(async () => {
       const { backfillRelations, proposeBackfillCandidates } = await import('../../core/kg-backfill.js');
+      const allRules = !!opts.allRules;
       const baseOpts = {
         project: opts.project,
         maxEdgesPerSource: opts.maxPerSource,
         minSharedTags: opts.minSharedTags,
         includeArchived: !!opts.includeArchived,
         dryRun: !!opts.dryRun,
+        includeSessionCooccurrence: allRules || !!opts.sessionCooccurrence,
+        includeNameTokenSimilarity: allRules || !!opts.nameTokens,
+        minNameJaccard: opts.minJaccard,
       };
       if (opts.dryRun) {
         const candidates = proposeBackfillCandidates(baseOpts);
@@ -731,6 +739,8 @@ kgCmd
       console.log(`Proposed ${result.candidatesProposed} relations, wrote ${result.edgesWritten} new edges.`);
       console.log(`  tag co-occurrence: ${result.byRule.tagCooccurrence}`);
       console.log(`  project clustering: ${result.byRule.projectClustering}`);
+      console.log(`  session co-occurrence: ${result.byRule.sessionCooccurrence}`);
+      console.log(`  name token similarity: ${result.byRule.nameTokenSimilarity}`);
       if (result.candidatesProposed > result.edgesWritten) {
         console.log(`  (${result.candidatesProposed - result.edgesWritten} candidates were already-existing edges; INSERT OR IGNORE skipped them.)`);
       }

--- a/src/transports/cli/cli.ts
+++ b/src/transports/cli/cli.ts
@@ -693,7 +693,7 @@ kgCmd
   .option('--include-archived', 'Also process archived entities')
   .option('--session-cooccurrence', 'Rule 3: link high-signal orphans co-created in the same session')
   .option('--name-tokens', 'Rule 4: link orphans sharing ≥2 name content tokens')
-  .option('--min-jaccard <n>', 'Jaccard threshold for name similarity (default 0.25)', parseFloat)
+  .option('--min-jaccard <n>', 'Jaccard threshold for name similarity (default 0.50)', parseFloat)
   .option('--all-rules', 'Enable all heuristic rules (Rules 1–4)')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {

--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -10,7 +10,7 @@ import { remember, recallEnhanced, forget, consolidate, exportMemories, importMe
 import { KnowledgeGraph } from '../../knowledge-graph.js';
 import { logCapabilities, readConfig, updateConfig, detectCapabilities } from '../../core/config.js';
 import { computePatterns } from '../../core/patterns.js';
-import { computeAnalytics } from '../../core/analytics.js';
+import { computeAnalytics, computePmAnalytics } from '../../core/analytics.js';
 import { computeStats } from '../../core/stats.js';
 import { computeProjects } from '../../core/projects.js';
 import { computeGraph } from '../../core/graph.js';
@@ -573,6 +573,13 @@ app.get('/v1/stats', (_req, res) => {
 });
 app.get('/v1/analytics', (_req, res) => {
   try { res.json({ success: true, data: computeAnalytics(getDatabase()) }); }
+  catch (err) { res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) }); }
+});
+app.get('/v1/analytics/pm', (req, res) => {
+  const raw = req.query.window;
+  const window = typeof raw === 'string' ? parseInt(raw, 10) : NaN;
+  const windowDays = Number.isFinite(window) && window > 0 ? window : 30;
+  try { res.json({ success: true, data: computePmAnalytics(getDatabase(), windowDays) }); }
   catch (err) { res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) }); }
 });
 // --- Demo seeder ---

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -192,6 +192,13 @@ describe('doctor', () => {
     const packageRoot = createPackageRoot();
     tempRoots.push(packageRoot);
 
+    // Isolate from the real ~/.memesh so inspectHookWiring reads a
+    // fresh dir with no install-hooks.json → returns warn, not fail.
+    const memeshDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-doctor-mdir-'));
+    tempRoots.push(memeshDir);
+    const originalMemeshDir = process.env.MEMESH_DIR;
+    process.env.MEMESH_DIR = memeshDir;
+
     const result = await runDoctor({
       packageRoot,
       packageVersion: '4.0.3',
@@ -219,6 +226,9 @@ describe('doctor', () => {
         guidance: 'Update this source checkout from its repository and rebuild it.',
       }),
     });
+
+    if (originalMemeshDir === undefined) delete process.env.MEMESH_DIR;
+    else process.env.MEMESH_DIR = originalMemeshDir;
 
     expect(result.status).toBe('PASS_WITH_CONCERNS');
     expect(result.checks.find((check) => check.id === 'config')?.status).toBe('pass');

--- a/tests/core/kg-backfill-integration.test.ts
+++ b/tests/core/kg-backfill-integration.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { backfillRelations } from '../../src/core/kg-backfill.js';
+
+const require = createRequire(import.meta.url);
+
+// Integration test: seed 50 entities across types and sessions,
+// run all 4 rules, verify orphan rate drops below 50%.
+describe('KG backfill — integration: orphan rate reduction', () => {
+  let testDir: string;
+  let dbPath: string;
+  let prevDbPath: string | undefined;
+  let Database: ReturnType<typeof require>;
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-kg-integration-'));
+    dbPath = path.join(testDir, 'test.db');
+    prevDbPath = process.env.MEMESH_DB_PATH;
+    process.env.MEMESH_DB_PATH = dbPath;
+    const { closeDatabase, openDatabase } = await import('../../src/db.js');
+    try { closeDatabase(); } catch { /* nothing open */ }
+    openDatabase();
+    Database = require('better-sqlite3');
+    db = new Database(dbPath);
+  });
+
+  afterEach(async () => {
+    db.close();
+    const { closeDatabase } = await import('../../src/db.js');
+    try { closeDatabase(); } catch { /* already closed */ }
+    if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
+    else process.env.MEMESH_DB_PATH = prevDbPath;
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('reduces orphan rate below 50% on a mixed 50-entity seed', () => {
+    // Helper to insert and return id
+    const insertEntity = (name: string, type: string, meta?: Record<string, unknown>): number => {
+      const r = db.prepare(
+        "INSERT INTO entities (name, type, status, metadata) VALUES (?, ?, 'active', ?)"
+      ).run(name, type, meta ? JSON.stringify(meta) : null);
+      return r.lastInsertRowid as number;
+    };
+
+    const insertTag = (eid: number, tag: string): void => {
+      db.prepare("INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)").run(eid, tag);
+    };
+
+    // Session groups: 5 sessions × 5 entities each (high-signal types)
+    const sessionTypes = ['lesson_learned', 'decision', 'feature', 'architecture', 'bug_fix'];
+    const sessionIds: number[][] = [];
+    for (let s = 0; s < 5; s++) {
+      const group: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const type = sessionTypes[i];
+        const id = insertEntity(
+          `${type} for auth module session ${s} item ${i}`,
+          type,
+          { signal_score: 0.8 }
+        );
+        insertTag(id, `session:sess${s}`);
+        insertTag(id, `project:projectA`);
+        group.push(id);
+      }
+      sessionIds.push(group);
+    }
+
+    // Name-token group: 10 entities sharing "auth flow" tokens
+    for (let i = 0; i < 5; i++) {
+      insertEntity(`auth flow configuration step ${i}`, 'feature', { signal_score: 0.7 });
+    }
+    for (let i = 0; i < 5; i++) {
+      insertEntity(`auth flow validation rule ${i}`, 'decision', { signal_score: 0.8 });
+    }
+
+    // Noise entities (session_keypoint / commit) — should remain orphans since low signal
+    for (let i = 0; i < 10; i++) {
+      const id = insertEntity(`session note ${i}`, 'session_keypoint', { signal_score: 0.1 });
+      insertTag(id, `session:sess${i % 5}`);
+    }
+
+    // Project anchor: one release in projectA for project clustering (Rule 2)
+    const releaseId = insertEntity('v1.0.0 auth module release', 'release');
+    insertTag(releaseId, 'project:projectA');
+
+    const before = (db.prepare(
+      "SELECT COUNT(*) AS n FROM entities e WHERE e.status='active' AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.from_entity_id=e.id OR r.to_entity_id=e.id)"
+    ).get() as { n: number }).n;
+
+    const total = (db.prepare("SELECT COUNT(*) AS n FROM entities WHERE status='active'").get() as { n: number }).n;
+    // 25 session entities + 10 name-token entities + 10 keypoints + 1 release = 46
+    expect(total).toBe(46);
+    expect(before).toBe(46); // all orphans before backfill
+
+    backfillRelations({
+      includeSessionCooccurrence: true,
+      includeNameTokenSimilarity: true,
+      maxEdgesPerSource: 3,
+      dryRun: false,
+    });
+
+    const orphansAfter = (db.prepare(
+      "SELECT COUNT(*) AS n FROM entities e WHERE e.status='active' AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.from_entity_id=e.id OR r.to_entity_id=e.id)"
+    ).get() as { n: number }).n;
+
+    const orphanRate = orphansAfter / total;
+    // Noise entities (10 session_keypoints with signal_score=0.1) and release
+    // will remain orphaned; high-signal entities should be connected
+    expect(orphanRate).toBeLessThan(0.50);
+  });
+});

--- a/tests/core/kg-backfill.test.ts
+++ b/tests/core/kg-backfill.test.ts
@@ -483,11 +483,12 @@ describe('kg-backfill integration', () => {
   // Rule 4: Name token similarity
   // ---------------------------------------------------------------------------
 
-  it('A4: links orphans sharing ≥2 content name tokens (shares-name-tokens)', () => {
-    const idG = insertEntity('memesh auth flow refactor', 'feature');
+  it('A4: links orphans sharing ≥3 content name tokens (shares-name-tokens)', () => {
+    // Shared tokens: {auth, module, session} = 3 ≥ default minSharedNameTokens (3)
+    const idG = insertEntity('memesh auth module session config', 'feature');
     setMetadata(idG, { signal_score: 0.65 });
 
-    const idH = insertEntity('auth flow session handling', 'bug_fix');
+    const idH = insertEntity('auth module session handler', 'bug_fix');
     setMetadata(idH, { signal_score: 0.7 });
 
     const result = backfillRelations({ includeNameTokenSimilarity: true, dryRun: false });
@@ -504,8 +505,9 @@ describe('kg-backfill integration', () => {
   });
 
   it('A4-jaccard: qualifies via Jaccard ≥ 0.25 even when shared token count < minSharedNameTokens', () => {
-    // tokens: {oauth,implementation} vs {oauth,module} → intersection=1, union=3 → Jaccard=0.33
-    const idI = insertEntity('oauth implementation', 'feature');
+    // tokens: {oauth,service} vs {oauth,module} → intersection=1, union=3 → Jaccard=0.33
+    // ("implementation" is a stopword → would leave only 1 token, excluded by size≥2 gate)
+    const idI = insertEntity('oauth service', 'feature');
     setMetadata(idI, { signal_score: 0.65 });
 
     const idJ = insertEntity('oauth module', 'architecture');

--- a/tests/core/kg-backfill.test.ts
+++ b/tests/core/kg-backfill.test.ts
@@ -460,6 +460,27 @@ describe('kg-backfill integration', () => {
     expect(after).toBe(before);
   });
 
+  it('A7: no duplicate (from,to) candidates when orphan shares multiple session tags with same peer', () => {
+    // orphan A and peer B both tagged session:s1 AND session:s2 → should only
+    // produce ONE co-created candidate (not two), keeping candidatesProposed honest.
+    const idA = insertEntity('lesson alpha', 'lesson_learned');
+    insertTag(idA, 'session:s1');
+    insertTag(idA, 'session:s2');
+    setMetadata(idA, { signal_score: 0.8 });
+
+    const idB = insertEntity('decision beta', 'decision');
+    insertTag(idB, 'session:s1');
+    insertTag(idB, 'session:s2');
+    setMetadata(idB, { signal_score: 0.8 });
+
+    const result = backfillRelations({ includeSessionCooccurrence: true, dryRun: true });
+    // One direction A→B (B is already a peer, not an orphan for its own outgoing edges
+    // in this minimal seed). Key assertion: candidatesProposed must equal edgesWritten
+    // path — i.e. no inflation from the duplicate session tag.
+    const abPairs = result.candidatesProposed;
+    expect(abPairs).toBeLessThanOrEqual(2); // at most A→B and B→A, never A→B twice
+  });
+
   it('A6: maxEdgesPerSource caps co-created edges from Rule 3', () => {
     const anchor = insertEntity('big lesson', 'lesson_learned');
     insertTag(anchor, 'session:s2');

--- a/tests/core/kg-backfill.test.ts
+++ b/tests/core/kg-backfill.test.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import os from 'os';
 import {
   isTopicalTag,
+  tokenizeName,
+  jaccardSimilarity,
   proposeBackfillCandidates,
   backfillRelations,
 } from '../../src/core/kg-backfill.js';
@@ -398,5 +400,172 @@ describe('kg-backfill integration', () => {
     // Rule 1 must propose nothing — all shared tags are system-literal noise
     const tagCooc = candidates.filter(c => c.relationType === 'related-to');
     expect(tagCooc).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule 3: Session co-occurrence
+  // ---------------------------------------------------------------------------
+
+  function setMetadata(entityId: number, meta: Record<string, unknown>): void {
+    db.prepare("UPDATE entities SET metadata = ? WHERE id = ?").run(JSON.stringify(meta), entityId);
+  }
+
+  it('A1: links two high-signal orphans sharing a session: tag (co-created)', () => {
+    const idA = insertEntity('lesson from auth work', 'lesson_learned');
+    insertTag(idA, 'session:abc123');
+    setMetadata(idA, { signal_score: 1.0 });
+
+    const idB = insertEntity('decision on auth approach', 'decision');
+    insertTag(idB, 'session:abc123');
+    setMetadata(idB, { signal_score: 0.9 });
+
+    const result = backfillRelations({ includeSessionCooccurrence: true, dryRun: false });
+    expect(result.byRule.sessionCooccurrence).toBeGreaterThanOrEqual(1);
+
+    const rel = db.prepare(
+      "SELECT * FROM relations WHERE from_entity_id=? AND to_entity_id=? AND relation_type='co-created'"
+    ).get(idA, idB);
+    expect(rel).toBeTruthy();
+  });
+
+  it('A2: excludes low-signal entities (signal_score < 0.6) from session co-occurrence', () => {
+    const idC = insertEntity('Duration: 0s noise', 'session_keypoint');
+    insertTag(idC, 'session:xyz789');
+    setMetadata(idC, { signal_score: 0.0 });
+
+    const idD = insertEntity('real decision', 'decision');
+    insertTag(idD, 'session:xyz789');
+    setMetadata(idD, { signal_score: 0.9 });
+
+    const result = backfillRelations({ includeSessionCooccurrence: true, dryRun: false });
+    // session_keypoint is not in sessionEligibleTypes; also score=0 < 0.6
+    expect(result.byRule.sessionCooccurrence).toBe(0);
+  });
+
+  it('A3: dry-run proposes co-created edges without writing', () => {
+    const idE = insertEntity('lesson X', 'lesson_learned');
+    insertTag(idE, 'session:s1');
+    setMetadata(idE, { signal_score: 1.0 });
+
+    const idF = insertEntity('decision Y', 'decision');
+    insertTag(idF, 'session:s1');
+    setMetadata(idF, { signal_score: 0.9 });
+
+    const before = countRelations();
+    const result = backfillRelations({ includeSessionCooccurrence: true, dryRun: true });
+    const after = countRelations();
+
+    expect(result.candidatesProposed).toBeGreaterThanOrEqual(1);
+    expect(result.edgesWritten).toBe(0);
+    expect(after).toBe(before);
+  });
+
+  it('A6: maxEdgesPerSource caps co-created edges from Rule 3', () => {
+    const anchor = insertEntity('big lesson', 'lesson_learned');
+    insertTag(anchor, 'session:s2');
+    setMetadata(anchor, { signal_score: 1.0 });
+
+    for (let i = 0; i < 5; i++) {
+      const id = insertEntity(`decision ${i}`, 'decision');
+      insertTag(id, 'session:s2');
+      setMetadata(id, { signal_score: 0.9 });
+    }
+
+    backfillRelations({ includeSessionCooccurrence: true, maxEdgesPerSource: 2, dryRun: false });
+
+    const edges = db.prepare(
+      "SELECT COUNT(*) AS n FROM relations WHERE from_entity_id=? AND relation_type='co-created'"
+    ).get(anchor) as { n: number };
+    expect(edges.n).toBeLessThanOrEqual(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule 4: Name token similarity
+  // ---------------------------------------------------------------------------
+
+  it('A4: links orphans sharing ≥2 content name tokens (shares-name-tokens)', () => {
+    const idG = insertEntity('memesh auth flow refactor', 'feature');
+    setMetadata(idG, { signal_score: 0.65 });
+
+    const idH = insertEntity('auth flow session handling', 'bug_fix');
+    setMetadata(idH, { signal_score: 0.7 });
+
+    const result = backfillRelations({ includeNameTokenSimilarity: true, dryRun: false });
+    expect(result.byRule.nameTokenSimilarity).toBeGreaterThanOrEqual(1);
+  });
+
+  it('A5: does NOT link orphans with only stopword name overlap', () => {
+    // After removing stopwords: {auth,bug} vs {login,issue} — 0 shared tokens
+    insertEntity('fix the auth bug', 'bug_fix');
+    insertEntity('fix the login issue', 'bug_fix');
+
+    const result = backfillRelations({ includeNameTokenSimilarity: true, dryRun: false });
+    expect(result.byRule.nameTokenSimilarity).toBe(0);
+  });
+
+  it('A4-jaccard: qualifies via Jaccard ≥ 0.25 even when shared token count < minSharedNameTokens', () => {
+    // tokens: {oauth,implementation} vs {oauth,module} → intersection=1, union=3 → Jaccard=0.33
+    const idI = insertEntity('oauth implementation', 'feature');
+    setMetadata(idI, { signal_score: 0.65 });
+
+    const idJ = insertEntity('oauth module', 'architecture');
+    setMetadata(idJ, { signal_score: 0.9 });
+
+    const result = backfillRelations({
+      includeNameTokenSimilarity: true,
+      minSharedNameTokens: 2,   // shared=1 < 2, but Jaccard=0.33 ≥ 0.25 still qualifies
+      minNameJaccard: 0.25,
+      dryRun: false,
+    });
+    expect(result.byRule.nameTokenSimilarity).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task A2: Pure-function unit tests for tokenizeName + jaccardSimilarity
+// ---------------------------------------------------------------------------
+
+describe('tokenizeName — content token extraction', () => {
+  it('lowercases and splits on non-word chars, removes stopwords', () => {
+    // 'fix' is a stopword; 'auth' and 'flow' are content tokens
+    expect(tokenizeName('Auth-Flow Fix')).toEqual(new Set(['auth', 'flow']));
+  });
+
+  it('filters tokens shorter than 3 chars', () => {
+    expect(tokenizeName('io vs go')).toEqual(new Set([]));
+  });
+
+  it('removes stopwords', () => {
+    expect(tokenizeName('fix the auth bug')).toEqual(new Set(['auth', 'bug']));
+  });
+
+  it('handles empty string', () => {
+    expect(tokenizeName('')).toEqual(new Set());
+  });
+
+  it('splits on underscores (non-word boundary)', () => {
+    expect(tokenizeName('session_auth_handler')).toEqual(new Set(['session', 'auth', 'handler']));
+  });
+});
+
+describe('jaccardSimilarity', () => {
+  it('returns 1.0 for identical sets', () => {
+    expect(jaccardSimilarity(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1.0);
+  });
+
+  it('returns 0.0 for disjoint sets', () => {
+    expect(jaccardSimilarity(new Set(['a']), new Set(['b']))).toBe(0.0);
+  });
+
+  it('computes partial overlap correctly', () => {
+    // intersection={auth,flow}, union={auth,flow,memesh,session} → 2/4 = 0.5
+    const a = new Set(['auth', 'flow', 'memesh']);
+    const b = new Set(['auth', 'flow', 'session']);
+    expect(jaccardSimilarity(a, b)).toBeCloseTo(0.5);
+  });
+
+  it('returns 0.0 when either set is empty', () => {
+    expect(jaccardSimilarity(new Set(), new Set(['a']))).toBe(0.0);
+    expect(jaccardSimilarity(new Set(['a']), new Set())).toBe(0.0);
   });
 });

--- a/tests/core/pm-analytics.test.ts
+++ b/tests/core/pm-analytics.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { computePmAnalytics } from '../../src/core/analytics.js';
+
+const require = createRequire(import.meta.url);
+
+describe('computePmAnalytics', () => {
+  let testDir: string;
+  let dbPath: string;
+  let prevDbPath: string | undefined;
+  let Database: ReturnType<typeof require>;
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-pm-analytics-'));
+    dbPath = path.join(testDir, 'test.db');
+    prevDbPath = process.env.MEMESH_DB_PATH;
+    process.env.MEMESH_DB_PATH = dbPath;
+    const { closeDatabase, openDatabase } = await import('../../src/db.js');
+    try { closeDatabase(); } catch { /* nothing open */ }
+    openDatabase();
+    Database = require('better-sqlite3');
+    db = new Database(dbPath);
+  });
+
+  afterEach(async () => {
+    db.close();
+    const { closeDatabase } = await import('../../src/db.js');
+    try { closeDatabase(); } catch { /* already closed */ }
+    if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
+    else process.env.MEMESH_DB_PATH = prevDbPath;
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const insertEntity = (name: string, type: string, daysAgo = 0, lastAccessedDaysAgo?: number): number => {
+    const createdAt = new Date(Date.now() - daysAgo * 86400 * 1000).toISOString();
+    const lastAccessed = lastAccessedDaysAgo !== undefined
+      ? new Date(Date.now() - lastAccessedDaysAgo * 86400 * 1000).toISOString()
+      : null;
+    const r = db.prepare(
+      "INSERT INTO entities (name, type, status, created_at, last_accessed_at) VALUES (?, ?, 'active', ?, ?)"
+    ).run(name, type, createdAt, lastAccessed);
+    return r.lastInsertRowid as number;
+  };
+
+  it('C1: decisionsPerWeek counts decisions created within the window', () => {
+    // 4 decisions within the last 14 days
+    insertEntity('decision A', 'decision', 2);
+    insertEntity('decision B', 'decision', 5);
+    insertEntity('decision C', 'decision', 10);
+    insertEntity('decision D', 'decision', 13);
+    // 1 decision outside the 14-day window — should not count
+    insertEntity('decision E', 'decision', 20);
+
+    const result = computePmAnalytics(db, 14);
+    // 4 decisions / (14/7 = 2 weeks) = 2.0
+    expect(result.velocity.decisionsPerWeek).toBeCloseTo(2.0);
+    expect(result.velocity.windowDays).toBe(14);
+  });
+
+  it('C1b: releasesPerMonth counts releases within the window', () => {
+    insertEntity('v1.0.0', 'release', 5);
+    insertEntity('v1.1.0', 'release', 25);
+    // outside 30-day window
+    insertEntity('v0.9.0', 'release', 40);
+
+    const result = computePmAnalytics(db, 30);
+    // 2 releases / (30/30 = 1 month) = 2.0
+    expect(result.velocity.releasesPerMonth).toBeCloseTo(2.0);
+  });
+
+  it('C2: stalePlanCount counts plan entities not accessed in 30+ days', () => {
+    // Stale: last accessed 45 days ago
+    insertEntity('old roadmap', 'plan', 50, 45);
+    // Active: last accessed 5 days ago
+    insertEntity('current sprint', 'plan', 10, 5);
+    // Never accessed — counts as stale (NULL last_accessed_at < threshold)
+    insertEntity('never accessed plan', 'plan', 60, undefined);
+
+    const result = computePmAnalytics(db, 90);
+    expect(result.staleness.stalePlanCount).toBe(2); // old roadmap + never accessed
+  });
+
+  it('C2b: openDecisionCount counts decisions older than 14d without supersedes relation', () => {
+    // Old unsuperseded decision
+    const oldDec = insertEntity('old auth decision', 'decision', 20);
+    // Old decision that was superseded
+    const superseded = insertEntity('old login decision', 'decision', 20);
+    // Link superseded with a supersedes relation
+    db.prepare(
+      "INSERT INTO relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, 'supersedes')"
+    ).run(superseded, oldDec);
+    // Recent decision (not yet 14 days old)
+    insertEntity('new decision', 'decision', 5);
+
+    const result = computePmAnalytics(db, 30);
+    // Only oldDec qualifies: old + no supersedes relation from it
+    expect(result.staleness.openDecisionCount).toBe(1);
+  });
+
+  it('C3: orphanRate = entities_without_relations / total_active', () => {
+    // 10 entities, 3 get relations
+    const ids = [];
+    for (let i = 0; i < 10; i++) {
+      ids.push(insertEntity(`entity ${i}`, 'knowledge'));
+    }
+    // Connect 3 entities
+    db.prepare(
+      "INSERT INTO relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, 'related-to')"
+    ).run(ids[0], ids[1]);
+    db.prepare(
+      "INSERT INTO relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, 'related-to')"
+    ).run(ids[2], ids[3]);
+
+    const result = computePmAnalytics(db, 30);
+    // ids[0], ids[1], ids[2], ids[3] have relations → 4 connected, 6 orphans
+    expect(result.connectedness.orphanRate).toBeCloseTo(6 / 10);
+    expect(result.connectedness.totalRelations).toBe(2);
+    expect(result.connectedness.activeEntities).toBe(10);
+  });
+
+  it('returns zero-valued result for empty database', () => {
+    const result = computePmAnalytics(db, 30);
+    expect(result.velocity.decisionsPerWeek).toBe(0);
+    expect(result.velocity.releasesPerMonth).toBe(0);
+    expect(result.staleness.stalePlanCount).toBe(0);
+    expect(result.staleness.openDecisionCount).toBe(0);
+    expect(result.connectedness.orphanRate).toBe(0);
+    expect(result.connectedness.totalRelations).toBe(0);
+    expect(result.connectedness.activeEntities).toBe(0);
+  });
+});

--- a/tests/transports/analytics.test.ts
+++ b/tests/transports/analytics.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import { openDatabase, closeDatabase } from '../../src/db.js';
 import { remember } from '../../src/core/operations.js';
-import { computeAnalytics, NOISE_TYPES } from '../../src/core/analytics.js';
+import { computeAnalytics, computePmAnalytics, NOISE_TYPES } from '../../src/core/analytics.js';
 
 let tmpDir: string;
 let db: Database.Database;
@@ -253,5 +253,33 @@ describe('/v1/analytics knowledgeRadar', () => {
     const result = computeAnalytics(db);
     const arch = result.knowledgeRadar.find(e => e.axis === 'architecture');
     expect(arch!.count).toBe(4);
+  });
+});
+
+// ── computePmAnalytics shape check ────────────────────────────────────────
+
+describe('computePmAnalytics — response shape', () => {
+  it('returns the expected PmAnalyticsResult structure on an empty DB', () => {
+    const result = computePmAnalytics(db, 30);
+    expect(result).toMatchObject({
+      velocity: { windowDays: 30, decisionsPerWeek: expect.any(Number), releasesPerMonth: expect.any(Number) },
+      staleness: { stalePlanCount: expect.any(Number), openDecisionCount: expect.any(Number) },
+      connectedness: { orphanRate: expect.any(Number), totalRelations: expect.any(Number), activeEntities: expect.any(Number) },
+    });
+  });
+
+  it('decisionsPerWeek and releasesPerMonth are ≥ 0', () => {
+    remember({ name: 'dec-a', type: 'decision', observations: ['decided x'] });
+    remember({ name: 'rel-a', type: 'release', observations: ['shipped v1'] });
+    const result = computePmAnalytics(db, 30);
+    expect(result.velocity.decisionsPerWeek).toBeGreaterThanOrEqual(0);
+    expect(result.velocity.releasesPerMonth).toBeGreaterThanOrEqual(0);
+  });
+
+  it('orphanRate is 1.0 when no relations exist', () => {
+    remember({ name: 'solo-a', type: 'knowledge', observations: ['alone'] });
+    remember({ name: 'solo-b', type: 'knowledge', observations: ['also alone'] });
+    const result = computePmAnalytics(db, 30);
+    expect(result.connectedness.orphanRate).toBeCloseTo(1.0);
   });
 });


### PR DESCRIPTION
## Summary

- **KG backfill Rules 3+4**: session co-occurrence + name-token similarity reduce real-KB orphan rate **89.2% → 11.7%** (1183 → 155 orphans) without any LLM
- **Roadmap milestone filter**: low-signal features (`signal_score < 0.65`) hidden from the milestone rail; releases always shown; "(N low-signal hidden)" badge when active
- **PM Analytics**: `GET /v1/analytics/pm` endpoint + `PmAnalyticsPanel` dashboard component — decision velocity, open decisions, KG orphan rate, total relations

## Test plan

- [x] 1010/1010 tests pass (`npm test -- --run`)
- [x] `memesh doctor` Overall: PASS
- [x] Real-KB dry-run verified before writing (2970 candidates, no Best-Practices/date noise)
- [x] Real-KB backfill executed: orphan rate 89.2% → 11.7%
- [x] Dashboard visual check completed
- [x] `npm run build` smoke tests pass (6/6)
- [x] Doc-sync checklist:
  - [x] CHANGELOG.md updated
  - [x] docs/ARCHITECTURE.md version header bumped to 4.3.0
  - [x] docs/api/API_REFERENCE.md — `GET /v1/analytics/pm` documented, version bumped
  - [x] CLAUDE.md — version header + test count + kg-backfill description updated
  - [x] package.json + plugin.json + marketplace.json all at 4.3.0
  - [x] dist/skills-manifest.json regenerated via `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)